### PR TITLE
Entity names

### DIFF
--- a/lib/doro/behaviors/exit.ex
+++ b/lib/doro/behaviors/exit.ex
@@ -3,8 +3,8 @@ defmodule Doro.Behaviors.Exit do
   import Doro.Comms
   alias Doro.Entity
 
-  def responds_to?(verb, ctx) do
-    verb == "exit" && ctx.object
+  def responds_to?(verb, _) do
+    verb == "exit"
   end
 
   def handle(%{verb: "exit", object: object, player: player}) do

--- a/lib/doro/behaviors/god.ex
+++ b/lib/doro/behaviors/god.ex
@@ -2,7 +2,7 @@ defmodule Doro.Behaviors.God do
   use Doro.Behavior
   import Doro.Comms
 
-  @verbs MapSet.new(~w(/reload /gistworld))
+  @verbs MapSet.new(~w(/reload /gistworld /entdump))
 
   def responds_to?(verb, _) do
     MapSet.member?(@verbs, verb)
@@ -19,6 +19,16 @@ defmodule Doro.Behaviors.God do
     |> Doro.World.clobber_from_gist()
 
     send_to_player(player, "Game state reloaded from gist.")
+  end
+
+  def handle(ctx = %{verb: "/entdump", player: player}) do
+    dump =
+      Regex.run(~r/\/entdump id:(\w+)/, ctx.original_command, capture: :all_but_first)
+      |> List.first()
+      |> Doro.World.get_entity()
+      |> Poison.encode!(pretty: true)
+
+    send_to_player(player, dump)
   end
 
   def handle(ctx), do: super(ctx)

--- a/lib/doro/behaviors/player.ex
+++ b/lib/doro/behaviors/player.ex
@@ -1,6 +1,7 @@
 defmodule Doro.Behaviors.Player do
   use Doro.Behavior
   import Doro.Comms
+  import Doro.SentenceConstruction
   alias Doro.World
 
   @verbs MapSet.new(~w(look halp inv i emote))
@@ -19,7 +20,7 @@ defmodule Doro.Behaviors.Player do
     # List entities
     Doro.World.entities_in_location(player.props.location)
     |> Enum.filter(&(&1.id != player.id))
-    |> Enum.each(fn e -> send_to_player(player, "#{Doro.Entity.name(e)} is here.") end)
+    |> Enum.each(fn e -> send_to_player(player, "#{indefinite(e)} is here.") end)
   end
 
   # we *could* do synonyms this way
@@ -27,7 +28,7 @@ defmodule Doro.Behaviors.Player do
 
   def handle(%{verb: "inv", player: player}) do
     Doro.World.entities_in_location(player.id)
-    |> Enum.each(fn e -> send_to_player(player, "You are carrying #{Doro.Entity.name(e)}.") end)
+    |> Enum.each(fn e -> send_to_player(player, "You are carrying #{indefinite(e)}.") end)
   end
 
   def handle(ctx = %{verb: "emote", player: player}) do

--- a/lib/doro/behaviors/portable.ex
+++ b/lib/doro/behaviors/portable.ex
@@ -8,8 +8,8 @@ defmodule Doro.Behaviors.Portable do
 
   @verbs MapSet.new(~w(take drop))
 
-  def responds_to?(verb, ctx) do
-    MapSet.member?(@verbs, verb) && ctx.object
+  def responds_to?(verb, _) do
+    MapSet.member?(@verbs, verb)
   end
 
   def handle(%{verb: "take", object: object, player: player}) do

--- a/lib/doro/behaviors/vascular_plant.ex
+++ b/lib/doro/behaviors/vascular_plant.ex
@@ -1,6 +1,7 @@
 defmodule Doro.Behaviors.VascularPlant do
   use Doro.Behavior
   alias Doro.Entity
+  import Doro.SentenceConstruction
 
   @prop :vascular_plant_hydration_level
   @default_hydration 10
@@ -11,9 +12,9 @@ defmodule Doro.Behaviors.VascularPlant do
 
   def handle(%{verb: "water", object: plant, player: player}) do
     plant = Doro.World.set_prop(plant, @prop, @default_hydration)
+    Doro.Comms.send_to_player(player, "You water #{definite(plant)}.")
+    Doro.Comms.send_to_others(player, "#{definite(player)} waters #{definite(plant)}.")
     broadcast_condition(plant)
-    Doro.Comms.send_to_player(player, "You water #{Entity.name(plant)}.")
-    Doro.Comms.send_to_others(player, "#{Entity.name(player)} waters #{Entity.name(plant)}.")
   end
 
   # Phenomenon
@@ -32,7 +33,7 @@ defmodule Doro.Behaviors.VascularPlant do
   defp broadcast_condition(plant) do
     Doro.Comms.send_to_location(
       plant[:location],
-      "#{Doro.Entity.name(plant)} looks #{desc(plant[@prop])}."
+      "#{definite(plant)} looks #{desc(plant[@prop])}."
     )
   end
 

--- a/lib/doro/behaviors/vascular_plant.ex
+++ b/lib/doro/behaviors/vascular_plant.ex
@@ -5,8 +5,8 @@ defmodule Doro.Behaviors.VascularPlant do
   @prop :vascular_plant_hydration_level
   @default_hydration 10
 
-  def responds_to?(verb, ctx) do
-    verb == "water" && ctx.object
+  def responds_to?(verb, _) do
+    verb == "water"
   end
 
   def handle(%{verb: "water", object: plant, player: player}) do

--- a/lib/doro/behaviors/visible.ex
+++ b/lib/doro/behaviors/visible.ex
@@ -3,10 +3,8 @@ defmodule Doro.Behaviors.Visible do
   import Doro.Comms
   alias Doro.Entity
 
-  @verbs MapSet.new(~w(look))
-
   def responds_to?(verb, ctx) do
-    MapSet.member?(@verbs, verb) && ctx.object
+    verb == "look" && ctx.player != ctx.object
   end
 
   def handle(%{verb: "look", player: player, object: object}) do

--- a/lib/doro/behaviors/visible.ex
+++ b/lib/doro/behaviors/visible.ex
@@ -1,14 +1,14 @@
 defmodule Doro.Behaviors.Visible do
   use Doro.Behavior
   import Doro.Comms
-  alias Doro.Entity
+  import Doro.SentenceConstruction
 
-  def responds_to?(verb, ctx) do
-    verb == "look" && ctx.player != ctx.object
+  def responds_to?(verb, %{player: player, object: object}) do
+    verb == "look" && player != object
   end
 
   def handle(%{verb: "look", player: player, object: object}) do
-    send_to_player(player, "#{Entity.name(object)} #{object.props.description}")
-    send_to_others(player, "#{Entity.name(player)} looks at #{Entity.name(object)} thoughtfully.")
+    send_to_player(player, "#{definite(object)} #{object.props.description}")
+    send_to_others(player, "#{definite(player)} looks at #{definite(object)} thoughtfully.")
   end
 end

--- a/lib/doro/entity.ex
+++ b/lib/doro/entity.ex
@@ -3,6 +3,8 @@ defmodule Doro.Entity do
 
   defstruct id: nil,
             behaviors: [],
+            name: nil,
+            name_tokens: nil,
             props: %{}
 
   def execute_behaviors(ctx) do
@@ -12,7 +14,7 @@ defmodule Doro.Entity do
   @doc "Returns the first behavior that can handle this verb in this context"
   def first_responder(entity = %Entity{}, ctx = %Doro.Context{verb: verb}) do
     behaviors(entity)
-    |> Enum.find(& &1.responds_to?(verb, ctx))
+    |> Enum.find(& &1.responds_to?(verb, %{ctx | object: entity}))
   end
 
   @doc "Returns all behaviors for this entity"
@@ -28,11 +30,12 @@ defmodule Doro.Entity do
     'pen' -> <redpen>, <bluepen>
   """
   def named?(entity, name) do
-    name == entity.id
+    entity.name_tokens
+    |> MapSet.member?(String.downcase(name))
   end
 
   def name(entity) do
-    "[#{entity.id}]"
+    "[#{entity.name}]"
   end
 
   @behaviour Access

--- a/lib/doro/entity.ex
+++ b/lib/doro/entity.ex
@@ -35,7 +35,16 @@ defmodule Doro.Entity do
   end
 
   def name(entity) do
-    "[#{entity.name}]"
+    entity.name || entity.id
+  end
+
+  def has_behavior?(entity, behavior) do
+    Enum.member?(entity.behaviors, behavior)
+  end
+
+  def is_person?(entity) do
+    entity
+    |> has_behavior?(Doro.Behaviors.Player)
   end
 
   @behaviour Access

--- a/lib/doro/sentence_construction.ex
+++ b/lib/doro/sentence_construction.ex
@@ -1,0 +1,19 @@
+defmodule Doro.SentenceConstruction do
+  def indefinite(entity = %Doro.Entity{name: name}) do
+    case Doro.Entity.is_person?(entity) do
+      true -> name
+      _ -> "#{indefinite_article(name)} #{name}"
+    end
+  end
+
+  def definite(entity = %Doro.Entity{name: name}) do
+    case Doro.Entity.is_person?(entity) do
+      true -> name
+      _ -> "the #{name}"
+    end
+  end
+
+  defp indefinite_article(s) do
+    if Regex.match?(~r/^[aeiou]/i, s), do: "an", else: "a"
+  end
+end

--- a/lib/doro/world/marshal.ex
+++ b/lib/doro/world/marshal.ex
@@ -24,10 +24,21 @@ defmodule Doro.World.Marshal do
     end)
   end
 
-  defp unmarshal_entity(entity) do
+  def unmarshal_entity(entity) do
     entity
     |> resolve_behaviors()
+    |> preprocess_name()
     |> (&struct(Doro.Entity, &1)).()
+  end
+
+  defp preprocess_name(entity) do
+    name = Map.get(entity, :name, entity.id) |> String.downcase()
+
+    Map.put(
+      entity,
+      :name_tokens,
+      [name | String.split(name)] |> MapSet.new()
+    )
   end
 
   defp resolve_behaviors(entity) do

--- a/lib/doro/world/world.ex
+++ b/lib/doro/world/world.ex
@@ -13,6 +13,8 @@ defmodule Doro.World do
   Finds named entities in specificied locations.
   """
   @spec get_named_entities_in_locations(String.t(), [String.t()]) :: [%Doro.Entity{}]
+  def get_named_entities_in_locations(nil, _), do: []
+
   def get_named_entities_in_locations(name, location_ids) do
     locations_set = MapSet.new(location_ids)
 

--- a/priv/game_state.json
+++ b/priv/game_state.json
@@ -4,7 +4,8 @@
       "id": "bathroom",
       "behaviors": [],
       "props": {
-        "description": "You are in a small, dingy bathroom; a flourescent light flickers overhead."
+        "description":
+          "You are in a small, dingy bathroom; a flourescent light flickers overhead."
       }
     },
     "office": {
@@ -16,10 +17,8 @@
     },
     "bathroom-door": {
       "id": "bathroom-door",
-      "behaviors": [
-        "exit",
-        "visible"
-      ],
+      "name": "WC Door",
+      "behaviors": ["exit", "visible"],
       "props": {
         "location": "office",
         "description": "A door emblazoned with 'WC'.",
@@ -28,10 +27,8 @@
     },
     "office-door": {
       "id": "office-door",
-      "behaviors": [
-        "exit",
-        "visible"
-      ],
+      "name": "Red Door",
+      "behaviors": ["exit", "visible"],
       "props": {
         "location": "bathroom",
         "description": "A red door.",
@@ -40,11 +37,8 @@
     },
     "player1": {
       "id": "player1",
-      "behaviors": [
-        "visible",
-        "player",
-        "god"
-      ],
+      "name": "Goose",
+      "behaviors": ["visible", "player", "god"],
       "props": {
         "location": "office",
         "description": "is disheveled and smelly."
@@ -52,10 +46,8 @@
     },
     "player2": {
       "id": "player2",
-      "behaviors": [
-        "visible",
-        "player"
-      ],
+      "name": "Viper",
+      "behaviors": ["visible", "player"],
       "props": {
         "location": "office",
         "description": "is wearing some nice artisinal gut covers."
@@ -63,11 +55,8 @@
     },
     "plant": {
       "id": "plant",
-      "behaviors": [
-        "visible",
-        "portable",
-        "vascular_plant"
-      ],
+      "name": "Fiddleleaf Fig",
+      "behaviors": ["visible", "portable", "vascular_plant"],
       "props": {
         "location": "office",
         "description": "is herbaceous, glabrous, and four-pinnate."
@@ -75,10 +64,8 @@
     },
     "lacroix": {
       "id": "lacroix",
-      "behaviors": [
-        "visible",
-        "portable"
-      ],
+      "name": "can of Lacroix",
+      "behaviors": ["visible", "portable"],
       "props": {
         "location": "office",
         "description": "is coconut flavored.  Yuck."
@@ -86,10 +73,8 @@
     },
     "annoying_clock": {
       "id": "annoying_clock",
-      "behaviors": [
-        "visible",
-        "clock"
-      ],
+      "name": "annoying clock",
+      "behaviors": ["visible", "clock"],
       "props": {
         "location": "office",
         "description": "just looks like it wants to annoy you."

--- a/test/doro/entity_test.exs
+++ b/test/doro/entity_test.exs
@@ -1,0 +1,31 @@
+defmodule Doro.EntityTest do
+  use ExUnit.Case, async: true
+
+  alias Doro.Entity
+
+  setup do
+    entity =
+      """
+      {
+        "id": "plant",
+        "name": "Fiddleleaf Fig",
+        "behaviors": ["visible", "portable", "vascular_plant"],
+        "props": {
+          "location": "office",
+          "description": "is herbaceous, glabrous, and four-pinnate."
+        }
+      }
+      """
+      |> Poison.decode!(keys: :atoms)
+      |> Doro.World.Marshal.unmarshal_entity()
+
+    [entity: entity]
+  end
+
+  test "named?/2", %{entity: entity} do
+    assert Entity.named?(entity, "fig")
+    assert Entity.named?(entity, "Fig")
+    assert Entity.named?(entity, "fiddleleaf")
+    assert Entity.named?(entity, "Fiddleleaf fig")
+  end
+end

--- a/test/doro/sentence_construction_test.exs
+++ b/test/doro/sentence_construction_test.exs
@@ -1,0 +1,21 @@
+defmodule Doro.SentenceConstructionTest do
+  use ExUnit.Case, async: true
+
+  import Doro.SentenceConstruction
+  alias Doro.Entity
+
+  test "subject/2" do
+    dusty = %Entity{name: "Dusty Cake"}
+    aromatic = %Entity{name: "Aromatic Cake"}
+    iceman = %Entity{name: "Iceman", behaviors: [Doro.Behaviors.Player]}
+
+    assert definite(dusty) == "the Dusty Cake"
+    assert indefinite(dusty) == "a Dusty Cake"
+
+    assert definite(aromatic) == "the Aromatic Cake"
+    assert indefinite(aromatic) == "an Aromatic Cake"
+
+    assert definite(iceman) == "Iceman"
+    assert indefinite(iceman) == "Iceman"
+  end
+end


### PR DESCRIPTION
## Summary
Adds a `name` property to `Entity`.  This allows commands like:

There is a can of lacroix here.
`> look can`
`> look lacroix` 

And some simple article generation for sentence construction.