### PR TITLE
Use ETS for game state

### DIFF
--- a/lib/doro/world/game_state.ex
+++ b/lib/doro/world/game_state.ex
@@ -1,45 +1,86 @@
 defmodule Doro.World.GameState do
-  use Agent
+  use GenServer
+
+  @table_name :entities
 
   def start_link() do
-    Agent.start_link(&read_debug_world/0, name: __MODULE__)
+    GenServer.start_link(
+      __MODULE__,
+      read_debug_world() |> Map.get(:entities) |> Map.values(),
+      name: __MODULE__
+    )
   end
 
   def set(new_state) do
-    Agent.update(__MODULE__, fn _ -> new_state end)
+    GenServer.call(__MODULE__, {:set_entities, Map.values(new_state.entities)})
   end
 
   def get_entity(nil), do: nil
 
   def get_entity(id) do
-    Agent.get(__MODULE__, fn world -> world.entities[id] end)
+    case :ets.lookup(@table_name, id) do
+      [{_, entity}] -> entity
+      _ -> nil
+    end
   end
 
   def get_entities(filter \\ & &1) do
-    Agent.get(__MODULE__, fn world ->
-      world.entities
-      |> Map.values()
-      |> Enum.filter(filter)
-    end)
+    all_entities()
+    |> Enum.filter(filter)
   end
 
   def set_prop(entity_id, key, value) when is_atom(key) do
-    Agent.update(__MODULE__, fn state ->
-      state
-      |> put_in([:entities, entity_id, key], value)
-    end)
+    GenServer.call(__MODULE__, {:set_entity_prop, entity_id, key, value})
   end
 
-  def add_entity(entity = %Doro.Entity{id: id}) do
-    Agent.update(__MODULE__, fn state ->
-      state
-      |> put_in([:entities, id], entity)
-    end)
+  def add_entity(entity = %Doro.Entity{}) do
+    add_entities([entity])
+  end
+
+  def add_entities(entities) do
+    GenServer.call(__MODULE__, {:insert_entities, entities})
   end
 
   defp read_debug_world do
     Path.join(:code.priv_dir(:doro), "game_state.json")
     |> File.read!()
     |> Doro.World.Marshal.unmarshal()
+  end
+
+  defp all_entities do
+    :ets.match(@table_name, {:_, :"$1"}) |> List.flatten()
+  end
+
+  @impl true
+  def init(default_entities) do
+    entities_table = :ets.new(@table_name, [:named_table, read_concurrency: true])
+    do_insert_entities(entities_table, default_entities)
+    {:ok, {entities_table}}
+  end
+
+  @impl true
+  def handle_call({:set_entity_prop, entity_id, key, value}, _from, {entities_table}) do
+    entity = get_entity(entity_id) |> put_in([key], value)
+    do_insert_entities(entities_table, [entity])
+    {:reply, entity, {entities_table}}
+  end
+
+  @impl true
+  def handle_call({:insert_entities, entities}, _from, {entities_table}) do
+    do_insert_entities(entities_table, entities)
+    {:reply, :ok, {entities_table}}
+  end
+
+  @impl true
+  def handle_call({:set_entities, entities}, _from, {entities_table}) do
+    :ets.delete_all_objects(entities_table)
+    do_insert_entities(entities_table, entities)
+    {:reply, :ok, {entities_table}}
+  end
+
+  def do_insert_entities(entities_table, entities) do
+    entities
+    |> Enum.map(&{&1.id, &1})
+    |> (&:ets.insert(entities_table, &1)).()
   end
 end

--- a/test/doro/world/game_state_test.exs
+++ b/test/doro/world/game_state_test.exs
@@ -1,0 +1,100 @@
+defmodule Doro.World.GameStateTest do
+  use ExUnit.Case, async: false
+
+  alias Doro.World.GameState
+  alias Doro.Entity
+
+  setup do
+    GameState.set(%{
+      entities: %{
+        "iceman" => %Doro.Entity{
+          id: "iceman",
+          name: "Ice Man",
+          props: %{location: "Below the hard deck"}
+        },
+        "maverick" => %Doro.Entity{
+          id: "maverick",
+          name: "Maverick",
+          props: %{location: "Somewhere over the Indian Ocean"}
+        }
+      }
+    })
+
+    :ok
+  end
+
+  describe "set/1" do
+    test "clears the game state and sets the new one" do
+      assert [%Entity{}, %Entity{}] = GameState.get_entities()
+
+      GameState.set(%{entities: %{"2" => %Doro.Entity{id: "2"}}})
+      assert [%Doro.Entity{id: "2"}] = GameState.get_entities()
+    end
+  end
+
+  describe "get_entity/1" do
+    test "returns an entity with the given id, or nil" do
+      assert %Doro.Entity{id: "iceman"} = GameState.get_entity("iceman")
+      assert is_nil(GameState.get_entity(nil))
+      assert is_nil(GameState.get_entity("unknown"))
+    end
+  end
+
+  describe "get_entities/1" do
+    test "returns all entities if no filter is passed" do
+      entities = GameState.get_entities()
+      assert length(entities) == 2
+      assert Enum.any?(entities, &(&1.id == "iceman"))
+      assert Enum.any?(entities, &(&1.id == "maverick"))
+    end
+
+    test "filters entities with filter function" do
+      assert [%Doro.Entity{id: "maverick"}] =
+               GameState.get_entities(&(&1[:location] == "Somewhere over the Indian Ocean"))
+    end
+  end
+
+  describe "set_prop/3" do
+    test "sets a property on the entity" do
+      entity = %Doro.Entity{id: "id"}
+      GameState.set(%{entities: %{"id" => entity}})
+
+      entity = GameState.set_prop("id", :location, "Berkeley")
+
+      # sets it locally
+      assert "Berkeley" == entity[:location]
+
+      # sets it in ets
+      assert "Berkeley" == GameState.get_entity("id")[:location]
+    end
+  end
+
+  describe "add_entity/1" do
+    test "inserts an entity into the game state" do
+      refute GameState.get_entity("new_entity")
+      GameState.add_entity(%Doro.Entity{id: "new_entity"})
+
+      assert GameState.get_entity("new_entity")
+    end
+  end
+
+  describe "add_entities/1" do
+    test "inserts multiple entities into the game state" do
+      refute GameState.get_entity("new_entity_1")
+      refute GameState.get_entity("new_entity_2")
+
+      GameState.add_entities([
+        %Doro.Entity{id: "new_entity_1"},
+        %Doro.Entity{id: "new_entity_2"}
+      ])
+
+      assert GameState.get_entity("new_entity_1")
+      assert GameState.get_entity("new_entity_2")
+    end
+  end
+
+  test "filters entities with filter function" do
+    assert [%Doro.Entity{id: "maverick"}] =
+             GameState.get_entities(&(&1[:location] == "Somewhere over the Indian Ocean"))
+  end
+end


### PR DESCRIPTION
## Summary
Switch from `Agent` to `:ets` for the game state.  Mostly for performance, and to solve the issue of changing prototype behavior at runtime.  

Right now, if you change the prototype during runtime, I *think* the behavior won't change for the instances, since the `proto` is looked up and baked into the instance at load time.  With the faster ETS backing store, my hope is we can use ids instead of instances for the `proto` property.  Also, we won't block on lookups across processes.


