### PR TITLE
Add a world file format that can load the game state from multiple sources

### DIFF
--- a/lib/doro/behaviors/god.ex
+++ b/lib/doro/behaviors/god.ex
@@ -9,14 +9,14 @@ defmodule Doro.Behaviors.God do
   end
 
   def handle(%{verb: "/reload", player: player}) do
-    Doro.World.clobber_from_default()
+    Doro.World.load_default()
     send_to_player(player, "Game state reloaded.")
   end
 
   def handle(ctx = %{verb: "/gistworld", player: player}) do
     Regex.run(~r/\/gistworld (\w+)/, ctx.original_command, capture: :all_but_first)
     |> List.first()
-    |> Doro.World.clobber_from_gist()
+    |> Doro.World.load_from_gist()
 
     send_to_player(player, "Game state reloaded from gist.")
   end

--- a/lib/doro/entity.ex
+++ b/lib/doro/entity.ex
@@ -7,6 +7,7 @@ defmodule Doro.Entity do
             behaviors: [],
             name: nil,
             name_tokens: nil,
+            src: nil,
             props: %{}
 
   def execute_behaviors(ctx) do

--- a/lib/doro/utils/utils.ex
+++ b/lib/doro/utils/utils.ex
@@ -1,0 +1,26 @@
+defmodule Doro.Utils do
+  @moduledoc """
+  The usual dumping ground
+  """
+
+  @doc "Returns the contents of the first file of the latest revision of a gist"
+  def load_gist(gist_id) do
+    "https://api.github.com/gists/#{gist_id}"
+    |> HTTPoison.get!()
+    |> Map.get(:body)
+    |> Poison.decode!(keys: :atoms)
+    |> Map.get(:files)
+    |> Map.values()
+    |> List.first()
+    |> Map.get(:raw_url)
+    |> HTTPoison.get!()
+    |> Map.get(:body)
+  end
+
+  @doc "Returns the contents at a URL"
+  def load_url(url) do
+    url
+    |> HTTPoison.get!()
+    |> Map.get(:body)
+  end
+end

--- a/lib/doro/world/game_state.ex
+++ b/lib/doro/world/game_state.ex
@@ -6,7 +6,7 @@ defmodule Doro.World.GameState do
   def start_link() do
     GenServer.start_link(
       __MODULE__,
-      read_debug_world() |> Map.get(:entities),
+      read_default_world() |> Map.get(:entities),
       name: __MODULE__
     )
   end
@@ -15,7 +15,7 @@ defmodule Doro.World.GameState do
     GenServer.call(__MODULE__, {:set_entities, new_state.entities})
   end
 
-  def get, do: all_entities
+  def get, do: all_entities()
 
   def get_entity(nil), do: nil
 
@@ -43,10 +43,10 @@ defmodule Doro.World.GameState do
     GenServer.call(__MODULE__, {:insert_entities, entities})
   end
 
-  defp read_debug_world do
-    Path.join(:code.priv_dir(:doro), "game_state.json")
-    |> File.read!()
-    |> Doro.World.Marshal.unmarshal()
+  defp read_default_world do
+    %{sources: ["priv_file://entities.json", "priv_file://base_prototypes.json"]}
+    |> Poison.encode!()
+    |> Doro.World.Loader.load()
   end
 
   defp all_entities do

--- a/lib/doro/world/loader.ex
+++ b/lib/doro/world/loader.ex
@@ -1,0 +1,79 @@
+defmodule Doro.World.Loader do
+  @moduledoc """
+  This module knows how to load doro world files.  It returns a map that can be passed to `Doro.GameState.set/1`.
+
+  A world file is a JSON file like this:
+  ```
+  {
+    "sources": [
+      "gist://da12988d0ac6b7eef0136e4fb7d74720",
+      "https://www.example.com/zones/shire.json",
+      "priv_file://default.json",
+      "priv_file://prototypes.json"
+    ]
+  }
+  ```
+
+  The sources are loaded in order.  Entities with colliding ids in subsequent sources overwrite
+  previous ones.  If no errors occur, the running game state is replaced.
+
+  The canonical prototypes should be the last in the list, so that the behavior for common entities
+  like `_player` are consistent.
+  """
+
+  require Logger
+
+  @doc "This takes a JSON string representing a world file, and loads it into the game state"
+  def load(s) do
+    s
+    |> Poison.decode!(keys: :atoms)
+    |> Map.get(:sources)
+    |> Enum.map(&load_source(Regex.run(~r/(\w+):\/\/(.*$)/, &1)))
+    |> aggregate_sources()
+  end
+
+  defp load_source([url, "http", _]), do: load_url(url)
+  defp load_source([url, "https", _]), do: load_url(url)
+
+  defp load_source([load_source, "priv_file", path]) do
+    filepath = Path.join(:code.priv_dir(:doro), path)
+    Logger.info("Loading entities from local file: #{filepath}")
+
+    Task.async(fn ->
+      {load_source, File.read!(filepath)}
+    end)
+  end
+
+  defp load_source([load_source, "gist", gist_id]) do
+    Logger.info("Loading entities from gist: #{gist_id}")
+
+    Task.async(fn ->
+      {load_source, Doro.Utils.load_gist(gist_id)}
+    end)
+  end
+
+  defp load_url(url) do
+    Logger.info("Loading entities from url: #{url}")
+
+    Task.async(fn ->
+      {url, Doro.Utils.load_url(url)}
+    end)
+  end
+
+  defp aggregate_sources(load_tasks) do
+    load_tasks
+    |> Enum.map(&Task.await/1)
+    |> Enum.map(&parse_entity_file/1)
+    |> Enum.reduce([], fn %{entities: entities}, acc ->
+      acc ++ entities
+    end)
+    |> (&%{entities: &1}).()
+    |> Doro.World.Marshal.unmarshal()
+  end
+
+  defp parse_entity_file({load_source, source}) do
+    # augment props with the load source
+    data = Poison.decode!(source, keys: :atoms)
+    %{data | entities: data.entities |> Enum.map(&Map.put(&1, :src, load_source))}
+  end
+end

--- a/lib/doro/world/marshal.ex
+++ b/lib/doro/world/marshal.ex
@@ -6,10 +6,16 @@ defmodule Doro.World.Marshal do
   """
 
   @doc "Unmarshals a world from a JSON string"
-  def unmarshal(json) do
+  def unmarshal(json) when is_binary(json) do
+    json
+    |> Poison.decode!(keys: :atoms)
+    |> unmarshal()
+  end
+
+  @doc "Unmarshals a world from a JSON string"
+  def unmarshal(json) when is_map(json) do
     entities =
       json
-      |> Poison.decode!(keys: :atoms)
       |> Map.get(:entities)
       |> Enum.map(&unmarshal_entity/1)
 

--- a/lib/doro_web/channels/hello_channel.ex
+++ b/lib/doro_web/channels/hello_channel.ex
@@ -4,7 +4,7 @@ defmodule DoroWeb.HelloChannel do
 
   def join("hello:" <> player_name, _, socket) do
     Logger.info("Initializing Phoenix Channel for player named '#{player_name}'")
-    player = Doro.World.find_or_create_player(player_name, "office")
+    player = Doro.World.find_or_create_player(player_name, "start")
     send(self(), {:after_join, player.id})
     {:ok, Phoenix.Socket.assign(socket, :player_id, player.id)}
   end

--- a/lib/doro_web/controllers/api/game_state_controller.ex
+++ b/lib/doro_web/controllers/api/game_state_controller.ex
@@ -2,7 +2,7 @@ defmodule DoroWeb.Api.GameStateController do
   use DoroWeb, :controller
 
   def create(conn, _params) do
-    Doro.World.clobber_from_default()
+    Doro.World.load_default()
     send_resp(conn, :ok, "")
   end
 
@@ -31,5 +31,5 @@ defmodule DoroWeb.Api.GameStateController do
     end
   end
 
-  defp reload_world(json), do: json |> Doro.World.clobber_from_string()
+  defp reload_world(json), do: json |> Doro.World.clobber()
 end

--- a/priv/base_prototypes.json
+++ b/priv/base_prototypes.json
@@ -1,0 +1,16 @@
+{
+  "entities": [
+    {
+      "id": "_player",
+      "behaviors": ["visible", "player"],
+      "props": {
+        "description": "is a generic player."
+      }
+    },
+    {
+      "id": "_god",
+      "proto": "_player",
+      "behaviors": ["god"]
+    }
+  ]
+}

--- a/priv/entities.json
+++ b/priv/entities.json
@@ -1,13 +1,15 @@
 {
-  "entities": [{
+  "entities": [
+    {
       "id": "bathroom",
       "behaviors": [],
       "props": {
-        "description": "You are in a small, dingy bathroom; a flourescent light flickers overhead."
+        "description":
+          "You are in a small, dingy bathroom; a flourescent light flickers overhead."
       }
     },
     {
-      "id": "office",
+      "id": "start",
       "behaviors": [],
       "props": {
         "description": "You are in a soul-crushing office."
@@ -88,7 +90,8 @@
       "behaviors": ["exit", "visible"],
       "props": {
         "location": "office",
-        "description": "is a small fire escape that looks like a fire hazard itself.",
+        "description":
+          "is a small fire escape that looks like a fire hazard itself.",
         "destination_id": "fire_escape"
       }
     },
@@ -158,7 +161,8 @@
       "proto": "_player",
       "props": {
         "location": "office",
-        "description": "is stern and trim.  He says, 'Top Gun rules of engagement are written for your safety and for that of your team.'"
+        "description":
+          "is stern and trim.  He says, 'Top Gun rules of engagement are written for your safety and for that of your team.'"
       }
     },
     {
@@ -203,22 +207,10 @@
       "behaviors": ["visible", "slot_machine"],
       "props": {
         "location": "bathroom",
-        "description": "is a Juki DNU-1541, threaded with some #69 bonded nylon.",
+        "description":
+          "is a Juki DNU-1541, threaded with some #69 bonded nylon.",
         "slot_machine_rewards": ["_backpack"]
       }
-    },
-
-    {
-      "id": "_player",
-      "behaviors": ["visible", "player"],
-      "props": {
-        "description": "is a generic player."
-      }
-    },
-    {
-      "id": "_god",
-      "proto": "_player",
-      "behaviors": ["god"]
     },
     {
       "id": "_backpack",
@@ -232,7 +224,8 @@
       "id": "turntable",
       "behaviors": ["visible", "turntable"],
       "props": {
-        "description": "is a Technics 1200 DJ Turntable.  It looks a little dusty.",
+        "description":
+          "is a Technics 1200 DJ Turntable.  It looks a little dusty.",
         "location": "closet"
       }
     }

--- a/priv/fixtures/loader_test_1.json
+++ b/priv/fixtures/loader_test_1.json
@@ -1,0 +1,12 @@
+{
+  "entities": [
+    {
+      "id": "loader-test-entity",
+      "name": "Entity from loader test 1"
+    },
+    {
+      "id": "loader-test-entity-2",
+      "name": "Entity 2 from loader test 1"
+    }
+  ]
+}

--- a/priv/fixtures/loader_test_2.json
+++ b/priv/fixtures/loader_test_2.json
@@ -1,0 +1,8 @@
+{
+  "entities": [
+    {
+      "id": "loader-test-entity",
+      "name": "Entity from loader test 2"
+    }
+  ]
+}

--- a/priv/world.json
+++ b/priv/world.json
@@ -1,0 +1,3 @@
+{
+  "sources": ["priv_file://entities.json", "priv_file://base_prototypes.json"]
+}

--- a/test/doro/behaviors/turntable_test.exs
+++ b/test/doro/behaviors/turntable_test.exs
@@ -3,7 +3,7 @@ defmodule Doro.Behaviors.TurntableTest do
 
   describe "handle(%{verb: use})/3" do
     setup do
-      read_fixture("turntable.json") |> Doro.World.clobber_from_string()
+      read_fixture("turntable.json") |> Doro.World.clobber()
       Doro.World.GameState.get() |> Doro.World.Marshal.marshal()
 
       %{
@@ -30,7 +30,7 @@ defmodule Doro.Behaviors.TurntableTest do
 
   describe "handle(%{verb: stop})/3" do
     setup do
-      read_fixture("turntable.json") |> Doro.World.clobber_from_string()
+      read_fixture("turntable.json") |> Doro.World.clobber()
       Doro.World.GameState.get() |> Doro.World.Marshal.marshal()
       Doro.World.get_entity("turntable") |> Doro.World.set_prop(:playing, true)
 

--- a/test/doro/world/loader_test.exs
+++ b/test/doro/world/loader_test.exs
@@ -1,0 +1,54 @@
+defmodule Doro.World.LoaderTest do
+  use ExUnit.Case, async: true
+
+  alias Doro.World.Loader
+  alias Doro.Entity
+
+  def make_world_file(sources) do
+    %{sources: sources} |> Poison.encode!()
+  end
+
+  describe "load/1" do
+    test "augments entities with the src attribute" do
+      game_state =
+        make_world_file(["priv_file://fixtures/loader_test_1.json"])
+        |> Loader.load()
+
+      assert %Entity{
+               src: "priv_file://fixtures/loader_test_1.json"
+             } = List.first(game_state.entities)
+    end
+
+    @tag :integration
+    test "can load from a gist" do
+      game_state =
+        make_world_file(["gist://4575360d2bfb37998093fefe2f4aa44f"])
+        |> Loader.load()
+
+      entity =
+        game_state.entities
+        |> Enum.find(&(&1.id == "entity_from_gist"))
+
+      assert %Entity{
+               id: "entity_from_gist",
+               name: "Entity from gist"
+             } = entity
+    end
+
+    @tag :integration
+    test "can load from a url" do
+      game_state =
+        make_world_file(["https://www.isnd.net/integration-tests/doro/entities.json"])
+        |> Loader.load()
+
+      entity =
+        game_state.entities
+        |> Enum.find(&(&1.id == "entity_from_url"))
+
+      assert %Entity{
+               id: "entity_from_url",
+               name: "Entity from url"
+             } = entity
+    end
+  end
+end

--- a/test/doro/world/marshal_test.exs
+++ b/test/doro/world/marshal_test.exs
@@ -5,7 +5,7 @@ defmodule Doro.World.MarshalTest do
 
   describe "marshal/1" do
     setup do
-      read_fixture("world.json") |> Doro.World.clobber_from_string()
+      read_fixture("world.json") |> Doro.World.clobber()
 
       %{
         marshalled: %{"entities" => Doro.World.GameState.get() |> Marshal.marshal()}

--- a/test/doro/world_test.exs
+++ b/test/doro/world_test.exs
@@ -14,7 +14,7 @@ defmodule Doro.WorldTest do
       ]
     }
     |> Poison.encode!()
-    |> World.clobber_from_string()
+    |> World.clobber()
 
     :ok
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.start()
+ExUnit.start(exclude: [:integration])
 
 Ecto.Adapters.SQL.Sandbox.mode(Doro.Repo, :manual)


### PR DESCRIPTION
## Summary
A monolithic world file was kind of a pain.  So this code allows for breaking the the world into a number of "sources", and it merges them into the single game state.

Now when you call `Doro.World.load(json)`, and `json` is something like:
```json
{
  "sources": [
    "priv_file://entities.json", 
    "priv_file://base_prototypes.json"
  ]
}
```
It will load from all the sources and merge all the entities into one game state.  Source schemes supported are:

- `priv_file://<path>`: Will load a file out of the `priv` directory
- `<url>`: Will fetch it via HTTP
- `gist://<gist_id>`: Loads it from a gist

In addition, it will augment each loaded `Entity` with a `src` attribute, which will be the original location from which it was loaded.  Eg. `"priv_file://entities.json"` from the above example.  This will allow for easier filtering in the world builder. 