### PR TITLE
New endpoints to update and create single entities

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,14 @@
+### Creating new things
+
+`POST /api/entities` with data
+```json
+{ 
+  "id": "quarter", 
+  "name": "quarter", 
+  "props": { 
+    "location":"start", 
+    "description": "is a dirty 25cent coin." 
+  } 
+}
+```
+

--- a/assets/js/react/components/EntityForm/EntityForm.css
+++ b/assets/js/react/components/EntityForm/EntityForm.css
@@ -1,8 +1,10 @@
 .EntityForm {
   padding: 20px;
+  top: 10px;
+  position: sticky
 }
 
-.EntityForm + .EntityForm {
+.EntityForm+.EntityForm {
   border-top: 1px solid #ccc;
 }
 
@@ -22,11 +24,11 @@
   text-transform: uppercase;
   text-align: right;
   margin-right: 10px;
-  flex:1;
+  flex: 1;
 }
 
 .EntityForm .form-input {
-  flex:4;
+  flex: 4;
 }
 
 .form-actions {
@@ -34,7 +36,7 @@
   justify-content: flex-end;
 }
 
-.form-actions button + button {
+.form-actions button+button {
   margin-left: 10px;
 }
 

--- a/assets/js/react/components/EntityForms/EntityForms.css
+++ b/assets/js/react/components/EntityForms/EntityForms.css
@@ -3,9 +3,11 @@
   text-align: left;
   font-size: 10px;
 }
-.EntityForms{
+
+.EntityForms {
   display: flex;
 }
+
 .EntityForms__addNew {
   padding: 0 20px;
   flex: 2;

--- a/lib/doro/behaviors/behavior.ex
+++ b/lib/doro/behaviors/behavior.ex
@@ -18,6 +18,16 @@ defmodule Doro.Behavior do
     |> Enum.filter(&Regex.match?(~r/^Elixir\.Doro\.Behaviors\./, Atom.to_string(&1)))
   end
 
+  def find(nil), do: nil
+  def find(""), do: nil
+
+  def find(behavior) when is_binary(behavior) do
+    all_behaviors()
+    |> Enum.find(fn entry ->
+      entry == String.to_atom("Elixir.Doro.Behaviors.#{Macro.camelize(behavior)}")
+    end)
+  end
+
   def execute(behavior, ctx = %Doro.Context{}) do
     behavior.handle(ctx)
   end

--- a/lib/doro/behaviors/turntable.ex
+++ b/lib/doro/behaviors/turntable.ex
@@ -1,7 +1,6 @@
 defmodule Doro.Behaviors.Turntable do
   use Doro.Behavior
   import Doro.Comms
-  import Doro.SentenceConstruction
 
   @spinning_message "The record is spinning at 33RPM."
 

--- a/lib/doro/entity.ex
+++ b/lib/doro/entity.ex
@@ -14,7 +14,7 @@ defmodule Doro.Entity do
     Enum.reduce(Entity.behaviors(ctx.object), ctx, fn behavior, acc -> behavior.handle(acc) end)
   end
 
-  @doc "Creates an entity"
+  @doc "Creates an entity based on a known prototype"
   def create(prototype_id, props, naming_fn) do
     prototype = Doro.World.get_entity(prototype_id)
 
@@ -24,6 +24,13 @@ defmodule Doro.Entity do
       proto: prototype_id,
       props: props
     }
+    |> preprocess_name()
+    |> (&struct(Entity, &1)).()
+  end
+
+  @doc "Creates an entity from raw args"
+  def create(entity = %{id: _, name: _}) do
+    entity
     |> preprocess_name()
     |> (&struct(Entity, &1)).()
   end
@@ -38,7 +45,7 @@ defmodule Doro.Entity do
   def behaviors(nil), do: []
 
   def behaviors(entity = %Entity{}) do
-    entity.behaviors ++ behaviors(World.get_entity(entity.proto))
+    (entity.behaviors || []) ++ behaviors(World.get_entity(entity.proto))
   end
 
   def has_behavior?(entity, behavior) do

--- a/lib/doro/world/marshal.ex
+++ b/lib/doro/world/marshal.ex
@@ -28,6 +28,14 @@ defmodule Doro.World.Marshal do
     |> Enum.map(&unresolve_behaviors/1)
   end
 
+  @doc "convert Map to an %Entity"
+  def unmarshal_entity(data) do
+    data
+    |> resolve_behaviors()
+    |> (&Doro.Entity.preprocess_name(&1)).()
+    |> (&struct(Doro.Entity, &1)).()
+  end
+
   defp marshal_entity(entity) do
     entity
     |> unresolve_behaviors
@@ -45,21 +53,16 @@ defmodule Doro.World.Marshal do
     |> Modules.to_underscore()
   end
 
-  defp unmarshal_entity(data) do
-    data
-    |> resolve_behaviors()
-    |> (&Doro.Entity.preprocess_name(&1)).()
-    |> (&struct(Doro.Entity, &1)).()
-  end
-
   defp resolve_behaviors(data) do
+    behaviors =
+      Map.get(data, :behaviors, [])
+      |> Enum.map(&Doro.Behavior.find/1)
+      |> Enum.filter(& &1)
+
     Map.put(
       data,
       :behaviors,
-      Enum.map(
-        Map.get(data, :behaviors, []),
-        &String.to_existing_atom("Elixir.Doro.Behaviors.#{Macro.camelize(&1)}")
-      )
+      behaviors
     )
   end
 end

--- a/lib/doro/world/marshal.ex
+++ b/lib/doro/world/marshal.ex
@@ -39,11 +39,6 @@ defmodule Doro.World.Marshal do
     |> (&struct(Doro.Entity, &1)).()
   end
 
-  defp marshal_entity(entity) do
-    entity
-    |> unresolve_behaviors
-  end
-
   defp unresolve_behaviors(nil), do: nil
   defp unresolve_behaviors(entity = %{behaviors: []}), do: entity
 

--- a/lib/doro/world/marshal.ex
+++ b/lib/doro/world/marshal.ex
@@ -1,6 +1,8 @@
 defmodule Doro.World.Marshal do
   require Logger
 
+  import MapHelpers
+
   @moduledoc """
   Functions for loading the world from JSON
   """
@@ -32,6 +34,7 @@ defmodule Doro.World.Marshal do
   def unmarshal_entity(data) do
     data
     |> resolve_behaviors()
+    |> atomize_props_keys()
     |> (&Doro.Entity.preprocess_name(&1)).()
     |> (&struct(Doro.Entity, &1)).()
   end
@@ -53,16 +56,21 @@ defmodule Doro.World.Marshal do
     |> Modules.to_underscore()
   end
 
-  defp resolve_behaviors(data) do
-    behaviors =
-      Map.get(data, :behaviors, [])
-      |> Enum.map(&Doro.Behavior.find/1)
-      |> Enum.filter(& &1)
+  defp atomize_props_keys(data) do
+    Map.put(
+      data,
+      :props,
+      Map.get(data, :props, %{}) |> atomize_keys
+    )
+  end
 
+  defp resolve_behaviors(data) do
     Map.put(
       data,
       :behaviors,
-      behaviors
+      Map.get(data, :behaviors, [])
+      |> Enum.map(&Doro.Behavior.find/1)
+      |> Enum.filter(& &1)
     )
   end
 end

--- a/lib/doro_web/channels/hello_channel.ex
+++ b/lib/doro_web/channels/hello_channel.ex
@@ -4,7 +4,7 @@ defmodule DoroWeb.HelloChannel do
 
   def join("hello:" <> player_name, _, socket) do
     Logger.info("Initializing Phoenix Channel for player named '#{player_name}'")
-    player = Doro.World.find_or_create_player(player_name, "office")
+    player = Doro.World.find_or_create_player(player_name, "start")
     send(self(), {:after_join, player.id})
     {:ok, Phoenix.Socket.assign(socket, :player_id, player.id)}
   end

--- a/lib/doro_web/channels/hello_channel.ex
+++ b/lib/doro_web/channels/hello_channel.ex
@@ -4,7 +4,7 @@ defmodule DoroWeb.HelloChannel do
 
   def join("hello:" <> player_name, _, socket) do
     Logger.info("Initializing Phoenix Channel for player named '#{player_name}'")
-    player = Doro.World.find_or_create_player(player_name, "start")
+    player = Doro.World.find_or_create_player(player_name, "office")
     send(self(), {:after_join, player.id})
     {:ok, Phoenix.Socket.assign(socket, :player_id, player.id)}
   end

--- a/lib/doro_web/controllers/api/behaviors_controller.ex
+++ b/lib/doro_web/controllers/api/behaviors_controller.ex
@@ -1,8 +1,6 @@
 defmodule DoroWeb.Api.BehaviorsController do
   use DoroWeb, :controller
 
-  import Inspector
-
   def index(conn, _params) do
     {:ok, modules} = :application.get_key(:doro, :modules)
 

--- a/lib/doro_web/controllers/api/entities_controller.ex
+++ b/lib/doro_web/controllers/api/entities_controller.ex
@@ -1,6 +1,8 @@
 defmodule DoroWeb.Api.EntitiesController do
   use DoroWeb, :controller
 
+  import MapHelpers
+
   def create(conn, params) do
     params
     |> insert_visible_behavior
@@ -40,11 +42,5 @@ defmodule DoroWeb.Api.EntitiesController do
       |> Enum.filter(& &1)
 
     params |> Map.put("behaviors", behaviors)
-  end
-
-  defp atomize_keys(nil), do: %{}
-
-  defp atomize_keys(map) do
-    for {key, val} <- map, into: %{}, do: {String.to_atom(key), val}
   end
 end

--- a/lib/doro_web/controllers/api/entities_controller.ex
+++ b/lib/doro_web/controllers/api/entities_controller.ex
@@ -1,0 +1,50 @@
+defmodule DoroWeb.Api.EntitiesController do
+  use DoroWeb, :controller
+
+  def create(conn, params) do
+    params
+    |> insert_visible_behavior
+    |> atomize_keys
+    |> Doro.World.Marshal.unmarshal_entity()
+    |> Doro.World.insert_entity()
+    |> case do
+      :ok ->
+        conn
+        |> json(%{message: "created entity: #{params["id"]}"})
+
+      _ ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{message: "failed to create entity"})
+    end
+  end
+
+  def update(conn, params) do
+    Doro.World.get_entity(params["id"])
+    |> Map.merge(
+      params
+      |> atomize_keys
+      |> Doro.World.Marshal.unmarshal_entity()
+    )
+    |> Doro.World.insert_entity()
+
+    conn
+    |> json(%{message: "updated entity #{params["id"]}"})
+  end
+
+  defp insert_visible_behavior(params) do
+    behaviors =
+      (["visible"] ++ [params["behaviors"]])
+      |> List.flatten()
+      |> Enum.uniq()
+      |> Enum.filter(& &1)
+
+    params |> Map.put("behaviors", behaviors)
+  end
+
+  defp atomize_keys(nil), do: %{}
+
+  defp atomize_keys(map) do
+    for {key, val} <- map, into: %{}, do: {String.to_atom(key), val}
+  end
+end

--- a/lib/doro_web/router.ex
+++ b/lib/doro_web/router.ex
@@ -27,6 +27,8 @@ defmodule DoroWeb.Router do
     get("/game_state", Api.GameStateController, :show)
     post("/game_state", Api.GameStateController, :update)
     put("/game_state", Api.GameStateController, :create)
+    put("/entities", Api.EntitiesController, :create)
+    post("/entities/:id", Api.EntitiesController, :update)
     get("/behaviors", Api.BehaviorsController, :index)
   end
 end

--- a/lib/shared/MapHelpers.ex
+++ b/lib/shared/MapHelpers.ex
@@ -1,0 +1,6 @@
+defmodule MapHelpers do
+  def atomize_keys(nil), do: %{}
+  def atomize_keys(map), do: for({key, val} <- map, into: %{}, do: atomize(key, val))
+  def atomize(key, val) when is_binary(key), do: {String.to_atom(key), val}
+  def atomize(key, val), do: {key, val}
+end

--- a/priv/entities.json
+++ b/priv/entities.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "closet-door",
-      "name": "Closet Door",
+      "name": "closet door",
       "behaviors": ["exit", "visible"],
       "props": {
         "location": "start",
@@ -41,7 +41,7 @@
     },
     {
       "id": "closet-exit-door",
-      "name": "Closet Door",
+      "name": "closet door",
       "behaviors": ["exit", "visible"],
       "props": {
         "location": "closet",

--- a/priv/fixtures/turntable.json
+++ b/priv/fixtures/turntable.json
@@ -1,21 +1,20 @@
 {
-  "entities": [
-    {
+  "entities": [{
       "id": "turntable",
       "name": "Turntable",
       "props": {
         "description": "Description of turntable.",
         "playing": null
-      }
+      },
+      "behaviors": ["visible", "turntable"]
     },
-    { 
+    {
       "id": "room"
     },
     {
       "id": "player",
       "name": "player prototype",
       "proto": "_player",
-      "behaviors": ["visible", "player"],
       "props": {
         "location": "room",
         "description": "is player prototype.  Put some props on the instance!"

--- a/test/doro/behavior_test.exs
+++ b/test/doro/behavior_test.exs
@@ -1,0 +1,22 @@
+defmodule Doro.BehaviorTest do
+  use ExUnit.Case, async: true
+
+  describe "&find/1" do
+    test "finds behavoirs by string if they exist" do
+      assert Doro.Behavior.find("visible") == Doro.Behaviors.Visible
+      assert Doro.Behavior.find("god") == Doro.Behaviors.God
+    end
+
+    test "returns nil for behaviors we don't know about" do
+      assert Doro.Behavior.find("totally_unknown_behavior") == nil
+    end
+
+    test "returns nil for nil" do
+      assert Doro.Behavior.find(nil) == nil
+    end
+
+    test "returns nil for empty string" do
+      assert Doro.Behavior.find("") == nil
+    end
+  end
+end

--- a/test/doro/behaviors/turntable_test.exs
+++ b/test/doro/behaviors/turntable_test.exs
@@ -1,6 +1,8 @@
 defmodule Doro.Behaviors.TurntableTest do
   use ExUnit.Case, async: false
 
+  import Doro.TestFixtures
+
   describe "handle(%{verb: use})/3" do
     setup do
       read_fixture("turntable.json") |> Doro.World.clobber()
@@ -54,11 +56,5 @@ defmodule Doro.Behaviors.TurntableTest do
       turntable = Doro.World.get_entity("turntable")
       refute ~r{33RPM} |> Regex.match?(turntable[:description])
     end
-  end
-
-  defp read_fixture(filename) do
-    "fixtures/#{filename}"
-    |> Path.expand(Application.app_dir(:doro, "priv"))
-    |> File.read!()
   end
 end

--- a/test/doro/world/marshal_test.exs
+++ b/test/doro/world/marshal_test.exs
@@ -1,6 +1,8 @@
 defmodule Doro.World.MarshalTest do
   use ExUnit.Case, async: true
 
+  import Doro.TestFixtures
+
   alias Doro.World.Marshal
 
   describe "marshal/1" do
@@ -51,11 +53,5 @@ defmodule Doro.World.MarshalTest do
 
   defp find_entity_by_id(entities, id) do
     entities |> Enum.find(fn entity -> entity |> Map.get(:id) == id end)
-  end
-
-  defp read_fixture(filename) do
-    "fixtures/#{filename}"
-    |> Path.expand(Application.app_dir(:doro, "priv"))
-    |> File.read!()
   end
 end

--- a/test/doro_web/api/entities_controller_test.exs
+++ b/test/doro_web/api/entities_controller_test.exs
@@ -1,0 +1,141 @@
+defmodule DoroWeb.Api.UserControllerTest do
+  use DoroWeb.ConnCase, async: false
+
+  import Doro.TestFixtures
+
+  describe "&create/2" do
+    setup do
+      Doro.World.clobber(%{entities: []})
+      %{params: %{id: "tomcat"}}
+    end
+
+    test "&create/2 creates a new entity in the game state with just an id", %{
+      conn: conn,
+      params: params
+    } do
+      response =
+        conn
+        |> put("/api/entities", params)
+        |> json_response(200)
+
+      assert response == %{"message" => "created entity: tomcat"}
+
+      expected_entity = %Doro.Entity{
+        behaviors: [Doro.Behaviors.Visible],
+        id: "tomcat",
+        name: "tomcat",
+        name_tokens: MapSet.new(["tomcat"]),
+        props: %{},
+        proto: nil
+      }
+
+      assert Doro.World.get_entity("tomcat") == expected_entity
+    end
+
+    test "&create/2 creates a new entity with specified behaviors", %{
+      conn: conn,
+      params: params
+    } do
+      extra_params = %{
+        behaviors: ["this", "turntable"]
+      }
+
+      conn
+      |> put("/api/entities", params |> Map.merge(extra_params))
+      |> json_response(200)
+
+      expected_entity = %Doro.Entity{
+        behaviors: [Doro.Behaviors.Visible, Doro.Behaviors.Turntable],
+        id: "tomcat",
+        name: "tomcat",
+        name_tokens: MapSet.new(["tomcat"]),
+        props: %{},
+        proto: nil
+      }
+
+      assert Doro.World.get_entity("tomcat") == expected_entity
+    end
+
+    test "&create/2 creates a new entity with the right props", %{
+      conn: conn,
+      params: params
+    } do
+      extra_params = %{
+        name: "the tomcat",
+        behaviors: nil,
+        props: %{location: "room", description: "this is the description"}
+      }
+
+      conn
+      |> put("/api/entities", params |> Map.merge(extra_params))
+      |> json_response(200)
+
+      entity = Doro.World.get_entity("tomcat")
+      assert entity.id == "tomcat"
+      assert entity.name == "the tomcat"
+      assert entity.name_tokens == MapSet.new(["the", "tomcat", "the tomcat"])
+      assert entity["location"] == "room"
+      assert entity.behaviors |> Enum.member?(Doro.Behaviors.Visible)
+    end
+  end
+
+  describe "&update/2" do
+    setup do
+      read_fixture("turntable.json") |> Doro.World.clobber_from_string()
+
+      %{params: %{id: "turntable", behaviors: ["visible", "slot_machine"]}}
+    end
+
+    test "&update/2 updates the entity with the new properties", %{
+      conn: conn,
+      params: params
+    } do
+      response =
+        conn
+        |> post("/api/entities/#{params[:id]}", %{
+          props: %{description: "whatever", playing: true}
+        })
+        |> json_response(200)
+
+      assert response == %{"message" => "updated entity turntable"}
+
+      updated = Doro.World.get_entity("turntable")
+      assert updated["playing"] == true
+    end
+
+    test "&update/2 updates the name and name tokens", %{
+      conn: conn,
+      params: params
+    } do
+      conn
+      |> post("/api/entities/#{params[:id]}", %{
+        name: "this name",
+        props: %{location: "somewhere"}
+      })
+      |> json_response(200)
+
+      updated = Doro.World.get_entity("turntable")
+      assert updated.name == "this name"
+      assert updated.name_tokens == MapSet.new(["this", "name", "this name"])
+      assert updated["location"] == "somewhere"
+    end
+
+    test "&update/2 updates behaviors by clobbering old behavior list with the new list", %{
+      conn: conn,
+      params: params
+    } do
+      original = Doro.World.get_entity("turntable")
+      assert original.behaviors |> Enum.member?(Doro.Behaviors.Visible)
+      assert original.behaviors |> Enum.member?(Doro.Behaviors.Turntable)
+
+      conn
+      |> post("/api/entities/#{params[:id]}", %{
+        behaviors: ["god"]
+      })
+      |> json_response(200)
+
+      updated = Doro.World.get_entity("turntable")
+      assert updated.behaviors == [Doro.Behaviors.God]
+    end
+  end
+end

--- a/test/doro_web/api/entities_controller_test.exs
+++ b/test/doro_web/api/entities_controller_test.exs
@@ -81,7 +81,7 @@ defmodule DoroWeb.Api.UserControllerTest do
 
   describe "&update/2" do
     setup do
-      read_fixture("turntable.json") |> Doro.World.clobber_from_string()
+      read_fixture("turntable.json") |> Doro.World.clobber()
 
       %{params: %{id: "turntable", behaviors: ["visible", "slot_machine"]}}
     end

--- a/test/doro_web/api/entities_controller_test.exs
+++ b/test/doro_web/api/entities_controller_test.exs
@@ -74,7 +74,7 @@ defmodule DoroWeb.Api.UserControllerTest do
       assert entity.id == "tomcat"
       assert entity.name == "the tomcat"
       assert entity.name_tokens == MapSet.new(["the", "tomcat", "the tomcat"])
-      assert entity["location"] == "room"
+      assert entity[:location] == "room"
       assert entity.behaviors |> Enum.member?(Doro.Behaviors.Visible)
     end
   end
@@ -100,7 +100,7 @@ defmodule DoroWeb.Api.UserControllerTest do
       assert response == %{"message" => "updated entity turntable"}
 
       updated = Doro.World.get_entity("turntable")
-      assert updated["playing"] == true
+      assert updated[:playing]
     end
 
     test "&update/2 updates the name and name tokens", %{
@@ -117,7 +117,7 @@ defmodule DoroWeb.Api.UserControllerTest do
       updated = Doro.World.get_entity("turntable")
       assert updated.name == "this name"
       assert updated.name_tokens == MapSet.new(["this", "name", "this name"])
-      assert updated["location"] == "somewhere"
+      assert updated[:location] == "somewhere"
     end
 
     test "&update/2 updates behaviors by clobbering old behavior list with the new list", %{

--- a/test/support/test_fixtures.ex
+++ b/test/support/test_fixtures.ex
@@ -1,0 +1,7 @@
+defmodule Doro.TestFixtures do
+  def read_fixture(filename) do
+    "fixtures/#{filename}"
+    |> Path.expand(Application.app_dir(:doro, "priv"))
+    |> File.read!()
+  end
+end


### PR DESCRIPTION
Problem
-------
to make the editor a bit easier to deal with, we need to have endpoints that
will simply take the entity as a hash and insert or updated it into the gamestate.

Solution
--------

* New Routes to new Api.EntitiesController
* build update and create endpoints
* moved behavior atomizing/finding into the Behavior module
* added Doro.TestFixtures.read_fixture helper

Notes
-----

I feel like some of this is messy (especially the tests) and I'm not sure
if it's that I don't know how to use Elixir or if i'm missing division
lines about where to put functions/modules etc.

Please comment on style/organization if you can see improvements.