### PR TITLE
Support omphaloskepsis

### DIFF
--- a/lib/doro/behaviors/visible.ex
+++ b/lib/doro/behaviors/visible.ex
@@ -3,16 +3,20 @@ defmodule Doro.Behaviors.Visible do
   import Doro.Comms
   import Doro.SentenceConstruction
 
-  interact_if("look", %{player: player, object: object}) do
-    player != object
-  end
-
-  interact("look", %{player: player, object: object}) do
-    send_to_player(player, first_person_description(object))
-    send_to_others(player, "#{definite(player)} looks at #{definite(object)} thoughtfully.")
+  interact_if("look", %{player: player, object: object, rest: rest}) do
+    player != object || Doro.Entity.named?(player, rest)
   end
 
   def first_person_description(entity) do
     "#{definite(entity)} #{entity[:description]}"
+  end
+
+  defp look_at(player, object) when player == object do
+    send_to_player(player, "You #{object[:description]}")
+  end
+
+  defp look_at(player, object) do
+    send_to_player(player, first_person_description(object))
+    send_to_others(player, "#{definite(player)} looks at #{definite(object)} thoughtfully.")
   end
 end

--- a/lib/doro/entity.ex
+++ b/lib/doro/entity.ex
@@ -75,6 +75,8 @@ defmodule Doro.Entity do
     'red' -> <redpen>
     'pen' -> <redpen>, <bluepen>
   """
+  def named?(_, nil), do: false
+
   def named?(entity, name) do
     entity.name_tokens
     |> MapSet.member?(String.downcase(name))


### PR DESCRIPTION
## Summary
Allow looking at oneself.  The descriptions may need to be changed to not include the verb "is".  I guess if each `Entity` is a singular then it would work to have descriptions like `"description": "brown door"` instead of `"description": "is a brown door"`.

Resolves #17.