### PR TITLE
Specify behavior properties when defining a behavior

### DIFF
--- a/lib/doro/behaviors/behavior.ex
+++ b/lib/doro/behaviors/behavior.ex
@@ -1,9 +1,9 @@
 defmodule Doro.Behavior do
-  defmacro __using__(_opts) do
+  defmacro __using__(struct_props \\ []) do
     quote do
       import Doro.Behavior
 
-      defstruct [:props]
+      defstruct unquote(struct_props)
 
       @canonical_verbs []
       @synonyms %{}

--- a/lib/doro/behaviors/exit.ex
+++ b/lib/doro/behaviors/exit.ex
@@ -1,5 +1,7 @@
 defmodule Doro.Behaviors.Exit do
-  use Doro.Behavior
+  use Doro.Behavior,
+    destination_id: nil
+
   import Doro.Comms
 
   interact("exit", ~w(go), %{

--- a/lib/doro/behaviors/slot_machine.ex
+++ b/lib/doro/behaviors/slot_machine.ex
@@ -1,5 +1,7 @@
 defmodule Doro.Behaviors.SlotMachine do
-  use Doro.Behavior
+  use Doro.Behavior,
+    slot_machine_rewards: []
+
   import Doro.Comms
   import Doro.SentenceConstruction
 

--- a/lib/doro/behaviors/turntable.ex
+++ b/lib/doro/behaviors/turntable.ex
@@ -1,5 +1,7 @@
 defmodule Doro.Behaviors.Turntable do
-  use Doro.Behavior
+  use Doro.Behavior,
+    playing: false
+
   import Doro.Comms
 
   @spinning_message "The record is spinning at 33RPM."

--- a/lib/doro/behaviors/visible.ex
+++ b/lib/doro/behaviors/visible.ex
@@ -1,5 +1,7 @@
 defmodule Doro.Behaviors.Visible do
-  use Doro.Behavior
+  use Doro.Behavior,
+    description: "is an entity"
+
   import Doro.Comms
   import Doro.SentenceConstruction
 

--- a/lib/doro_web/controllers/api/behaviors_controller.ex
+++ b/lib/doro_web/controllers/api/behaviors_controller.ex
@@ -2,20 +2,18 @@ defmodule DoroWeb.Api.BehaviorsController do
   use DoroWeb, :controller
 
   def index(conn, _params) do
-    {:ok, modules} = :application.get_key(:doro, :modules)
+    behaviors = Doro.Behavior.all_behaviors()
 
-    behaviors =
-      modules
-      |> Enum.reduce([], fn module, acc ->
-        Code.ensure_loaded(module)
+    behavior_shapes =
+      behaviors
+      |> Enum.map(& {&1.key(), (struct(&1) |> Map.drop([:__struct__]))})
+      |> Enum.into(%{})
 
-        case Keyword.get(module.__info__(:functions), :__behavior?) do
-          nil -> acc
-          0 -> [module |> Modules.to_underscore() | acc]
-        end
-      end)
+    behavior_keys =
+      behaviors
+      |> Enum.map(& &1.key())
 
     conn
-    |> json(%{behaviors: behaviors})
+    |> json(%{behaviors: behavior_keys, behavior_shapes: behavior_shapes})
   end
 end


### PR DESCRIPTION
## Problem
Since behaviors are now structs with their own behavior-specific properties, we need some way to let the editor know which properties are valid for which behaviors.  For instance, an `Exit` needs a `destination_id`.

## Solution
Explicitly specify the properties when defining a behavior:

```elixir
defmodule Doro.Behaviors.Bird do
  use Doro.Behavior, wingspan: 0, call: "chirp"
end
```

And return some additional data with `/api/behaviors`:

```json
{
  "behaviors": ["bird"],
  "behavior_shapes": {
    "bird": {
      "wingspan": 0,
      "call": "chirp"
    }
  }
}
```