### PR TITLE
Behaviors must be consistent in their shape in entities.json (and related files)

### DIFF
--- a/priv/entities.json
+++ b/priv/entities.json
@@ -35,7 +35,7 @@
         {
           "type": "visible",
           "description": "You are in a tiny dark closet."
-        }        
+        }
       ]
     },
     {
@@ -267,7 +267,9 @@
           "type": "visible",
           "description": "is coconut flavored.  Yuck."
         },
-        "portable"
+        {
+          "type": "portable"
+        }
       ]
     },
     {
@@ -281,7 +283,9 @@
           "type": "visible",
           "description": "is a well-loved Bird scooter."
         },
-        "portable"
+        {
+          "type": "portable"
+        }
       ]
     },
     {
@@ -310,7 +314,9 @@
           "type": "visible",
           "description": "is a generic backpack."
         },
-        "portable"
+        {
+          "type": "portable"
+        }
       ]
     },
     {
@@ -324,7 +330,9 @@
           "description":
             "is a Technics 1200 DJ Turntable.  It looks a little dusty."
         },
-        "turntable"
+        {
+          "type": "turntable"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Problem
-------

The game state editor is counting on the marshaled behaviors to have (at a minimum)
`{ type: "behavior name" }`

Up to now, it seems that in the entities json files, only the visible behavior was moved over.
The elixir side seemed to handle a behavior list like

```
[ 
  { type: 'visible', ... },
  'portable'
]
```
with no issue, but the editor was not built to support that.

Solution
--------
I propose that we require the behaviors to be an object with type.  they don't have to have anything
else in them.

If this is no good, then the front end parser is going to need some mods.

Changes
-------

* update entities.json so that `portable` and `turntable` behaviors are specified with a type like `{ type: 'portable' }`

With this fix, when I `/edit lacroix` it shows the `portable` behavior in the editor (which was not happening before).

<img width="709" alt="screen shot 2018-08-29 at 11 21 04 pm" src="https://user-images.githubusercontent.com/427380/44833215-41d16280-abe2-11e8-809f-1883c613b49d.png">
