### PR TITLE
Add Delete button in UI

### DIFF
--- a/assets/js/react/GameStateEditor/GameStateEditor.jsx
+++ b/assets/js/react/GameStateEditor/GameStateEditor.jsx
@@ -40,7 +40,7 @@ class GameStateEditor extends Component {
 
   handleEdit = entity => {
     this.props.fetchEntities()
-    this.setState({entity})
+    this.setState({ entity })
   }
 
   handleDownloadNewEntities = _ev => {
@@ -48,7 +48,7 @@ class GameStateEditor extends Component {
     this.props.downloadEntities({
       entities: filter(entry => !entry.src, entities),
       filename: "new-entities.json"
-    });
+    })
   }
 
   handleDownloadEntities = _ev => {
@@ -66,7 +66,7 @@ class GameStateEditor extends Component {
           <div className="GameStateEditor__addNew">
             <EntityForm />
           </div>
-        ),
+        )
       },
       {
         name: "Entities",

--- a/assets/js/react/GameStateEditor/GameStateEditor.jsx
+++ b/assets/js/react/GameStateEditor/GameStateEditor.jsx
@@ -85,13 +85,13 @@ class GameStateEditor extends Component {
           <header>
             <div className="GameStateEditor__actions">
               <button
-                className="GameStateEditor__download button"
+                className="GameStateEditor__download GameStateEditor__download--all button"
                 onClick={this.handleDownloadEntities}
               >
                 Download All Entities
               </button>
               <button
-                className="GameStateEditor__download button"
+                className="GameStateEditor__download GameStateEditor__download--new button"
                 onClick={this.handleDownloadNewEntities}
               >
                 Download New Entities

--- a/assets/js/react/GameStateEditor/GameStateEditor.jsx
+++ b/assets/js/react/GameStateEditor/GameStateEditor.jsx
@@ -40,15 +40,13 @@ class GameStateEditor extends Component {
 
   handleEdit = entity => {
     this.props.fetchEntities()
-    this.setState({
-      entity: entity
-    })
+    this.setState({entity})
   }
 
   handleDownloadNewEntities = _ev => {
     const { entities } = this.props
     this.props.downloadEntities({
-      entities: filter(entry => entry.src == null, entities),
+      entities: filter(entry => !entry.src, entities),
       filename: "new-entities.json"
     });
   }

--- a/assets/js/react/GameStateEditor/GameStateEditor.jsx
+++ b/assets/js/react/GameStateEditor/GameStateEditor.jsx
@@ -9,7 +9,11 @@ import FlashMessage from "../shared/components/Flash/Flash"
 import CurrentEntities from "./components/CurrentEntities/CurrentEntities"
 import EntityForm from "./components/EntityForm/EntityForm"
 import TabSet from "../shared/components/TabSet/TabSet"
-import { fetchEntities, downloadEntities } from "./actions/gameStateEditor"
+import {
+  fetchEntities,
+  downloadEntities,
+  activateTab
+} from "./actions/gameStateEditor"
 
 class GameStateEditor extends Component {
   static propTypes = {
@@ -41,13 +45,6 @@ class GameStateEditor extends Component {
     })
   }
 
-  handleDelete = entity => {
-    // const { entities } = this.props
-    // this.setState({
-    //   entities: filter(entry => entry.id !== entity.id, entities)
-    // })
-  }
-
   handleDownloadNewEntities = _ev => {
     const { entities } = this.props
     this.props.downloadEntities({
@@ -59,12 +56,6 @@ class GameStateEditor extends Component {
   handleDownloadEntities = _ev => {
     const { entities } = this.props
     this.props.downloadEntities({ entities: entities })
-  }
-
-  handleClear = _ev => {
-    // this.setState({
-    //   entities: []
-    // })
   }
 
   renderTabs = () => {
@@ -109,7 +100,7 @@ class GameStateEditor extends Component {
               </button>
             </div>
           </header>
-          <main>{this.renderTabs()}</main>
+          <div>{this.renderTabs()}</div>
         </section>
       </div>
     )

--- a/assets/js/react/GameStateEditor/GameStateEditor.test.js
+++ b/assets/js/react/GameStateEditor/GameStateEditor.test.js
@@ -33,7 +33,7 @@ describe("GameStateEditor", () => {
   describe("with some entities", () => {
     const entities = [
       { src: "priv_file://world.json", id: "one" },
-      { src: "gist://aa44ff",  id: "two" },
+      { src: "gist://aa44ff", id: "two" },
       { id: "three" },
       { src: "", id: "four" }
     ]
@@ -50,23 +50,18 @@ describe("GameStateEditor", () => {
       expect(fetchEntitiesSpy).not.toHaveBeenCalled()
     })
     it("download all calls download with all entities", () => {
-      wrapper.find('.GameStateEditor__download--all').simulate('click')
+      wrapper.find(".GameStateEditor__download--all").simulate("click")
       expect(downloadEntitiesSpy).toHaveBeenCalled()
       expect(downloadEntitiesSpy.mock.calls[0]).toEqual([
-        expect.objectContaining(
-          { entities: entities }
-        )
+        expect.objectContaining({ entities: entities })
       ])
     })
     it("download new entities calls download with only entities that have not src", () => {
-      wrapper.find('.GameStateEditor__download--new').simulate('click')
+      wrapper.find(".GameStateEditor__download--new").simulate("click")
       expect(downloadEntitiesSpy).toHaveBeenCalled()
       expect(downloadEntitiesSpy.mock.calls[0]).toEqual([
-        expect.objectContaining(
-          { entities: entities.slice(2,4) }
-        )
+        expect.objectContaining({ entities: entities.slice(2, 4) })
       ])
     })
   })
-
 })

--- a/assets/js/react/GameStateEditor/GameStateEditor.test.js
+++ b/assets/js/react/GameStateEditor/GameStateEditor.test.js
@@ -6,15 +6,21 @@ import { GameStateEditor } from "./GameStateEditor"
 
 describe("GameStateEditor", () => {
   let fetchEntitiesSpy = jest.fn()
+  let downloadEntitiesSpy = jest.fn()
   let wrapper
 
   beforeEach(() => {
-    fetchEntitiesSpy.mockReset();
+    fetchEntitiesSpy.mockReset()
+    downloadEntitiesSpy.mockReset()
   })
 
   describe("with no data", () => {
     beforeEach(() => {
-      wrapper = shallow(<GameStateEditor fetchEntities={fetchEntitiesSpy} />)
+      const props = {
+        fetchEntities: fetchEntitiesSpy,
+        downloadEntities: downloadEntitiesSpy
+      }
+      wrapper = shallow(<GameStateEditor {...props} />)
     })
     it("renders without crashing", () => {
       expect(wrapper).toBeTruthy()
@@ -22,6 +28,45 @@ describe("GameStateEditor", () => {
     it("fetches entities", () => {
       expect(fetchEntitiesSpy).toHaveBeenCalled()
     })
-
   })
+
+  describe("with some entities", () => {
+    const entities = [
+      { src: "priv_file://world.json", id: "one" },
+      { src: "gist://aa44ff",  id: "two" },
+      { id: "three" },
+      { src: "", id: "four" }
+    ]
+
+    beforeEach(() => {
+      const props = {
+        entities: entities,
+        fetchEntities: fetchEntitiesSpy,
+        downloadEntities: downloadEntitiesSpy
+      }
+      wrapper = shallow(<GameStateEditor {...props} />)
+    })
+    it("does not fetch entities if they are provided", () => {
+      expect(fetchEntitiesSpy).not.toHaveBeenCalled()
+    })
+    it("download all calls download with all entities", () => {
+      wrapper.find('.GameStateEditor__download--all').simulate('click')
+      expect(downloadEntitiesSpy).toHaveBeenCalled()
+      expect(downloadEntitiesSpy.mock.calls[0]).toEqual([
+        expect.objectContaining(
+          { entities: entities }
+        )
+      ])
+    })
+    it("download new entities calls download with only entities that have not src", () => {
+      wrapper.find('.GameStateEditor__download--new').simulate('click')
+      expect(downloadEntitiesSpy).toHaveBeenCalled()
+      expect(downloadEntitiesSpy.mock.calls[0]).toEqual([
+        expect.objectContaining(
+          { entities: entities.slice(2,4) }
+        )
+      ])
+    })
+  })
+
 })

--- a/assets/js/react/GameStateEditor/actions/gameStateEditor.js
+++ b/assets/js/react/GameStateEditor/actions/gameStateEditor.js
@@ -8,6 +8,8 @@ export const DELETE_ENTITY = "gameStateEditor/DELETE_ENTITY"
 export const DELETE_ENTITY_SUCCESS = "gameStateEditor/DELETE_ENTITY_SUCCESS"
 export const DELETE_ENTITY_FAILURE = "gameStateEditor/DELETE_ENTITY_FAILURE"
 
+export const ACTIVATE_TAB = "gameStateEditor/ACTIVATE_TAB"
+
 export const fetchEntities = data => ({ type: FETCH_ENTITIES, data })
 export const fetchEntitiesSuccess = data => ({
   type: FETCH_ENTITIES_SUCCESS,
@@ -29,3 +31,5 @@ export const deleteEntityFailure = data => ({
   type: DELETE_ENTITY_FAILURE,
   data
 })
+
+export const activateTab = data => ({type: ACTIVATE_TAB, data})

--- a/assets/js/react/GameStateEditor/actions/gameStateEditor.js
+++ b/assets/js/react/GameStateEditor/actions/gameStateEditor.js
@@ -4,6 +4,10 @@ export const FETCH_ENTITIES_FAILURE = "gameStateEditor/FETCH_ENTITIES_FAILURE"
 
 export const DOWNLOAD_ENTITIES = "gameStateEditor/DOWNLOAD_ENTITIES"
 
+export const DELETE_ENTITY = "gameStateEditor/DELETE_ENTITY"
+export const DELETE_ENTITY_SUCCESS = "gameStateEditor/DELETE_ENTITY_SUCCESS"
+export const DELETE_ENTITY_FAILURE = "gameStateEditor/DELETE_ENTITY_FAILURE"
+
 export const fetchEntities = data => ({ type: FETCH_ENTITIES, data })
 export const fetchEntitiesSuccess = data => ({
   type: FETCH_ENTITIES_SUCCESS,
@@ -15,3 +19,13 @@ export const fetchEntitiesFailure = data => ({
 })
 
 export const downloadEntities = data => ({ type: DOWNLOAD_ENTITIES, data })
+
+export const deleteEntity = data => ({ type: DELETE_ENTITY, data })
+export const deleteEntitySuccess = data => ({
+  type: DELETE_ENTITY_SUCCESS,
+  data
+})
+export const deleteEntityFailure = data => ({
+  type: DELETE_ENTITY_FAILURE,
+  data
+})

--- a/assets/js/react/GameStateEditor/actions/gameStateEditor.js
+++ b/assets/js/react/GameStateEditor/actions/gameStateEditor.js
@@ -32,4 +32,4 @@ export const deleteEntityFailure = data => ({
   data
 })
 
-export const activateTab = data => ({type: ACTIVATE_TAB, data})
+export const activateTab = data => ({ type: ACTIVATE_TAB, data })

--- a/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
+++ b/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
@@ -7,7 +7,7 @@ import { isArray, some, filter, get, map } from "lodash"
 import { isEmpty } from "../../../shared/utils/utilities"
 
 import Entity from "../Entity/Entity"
-import { fetchEntities } from "../../actions/gameStateEditor"
+import { fetchEntities, deleteEntity } from "../../actions/gameStateEditor"
 
 class CurrentEntities extends Component {
   static propTypes = {
@@ -31,9 +31,8 @@ class CurrentEntities extends Component {
     }
   }
 
-  handleSearch = ev => {
-    const query = ev.target.value.trim()
-    let filteredEntities = this.props.entities
+  filterEntities = (entities, query) => {
+    let filteredEntities = entities || [];
 
     if (!isEmpty(query)) {
       const fieldMatcher = (field, query) => entity => {
@@ -57,18 +56,27 @@ class CurrentEntities extends Component {
         fieldsMatcher(fields, query)
       )
     }
+    return filteredEntities;
+  }
+
+  handleSearch = ev => {
+    const query = ev.target.value.trim()
     this.setState({
-      query: query,
-      filteredEntities: filteredEntities
+      query: query
     })
   }
 
   handleEdit = () => {}
-  handleDelete = () => {}
+
+  handleDelete = (id) => {
+    return () => {
+      this.props.deleteEntity(id)
+    }
+  }
 
   render() {
-    let { filteredEntities, query } = this.state
-    filteredEntities = filteredEntities || this.props.entities
+    let { query } = this.state
+    const filteredEntities = this.filterEntities(this.props.entities, query)
     return (
       <div className="CurrentEntities">
         <form>
@@ -84,10 +92,10 @@ class CurrentEntities extends Component {
         </div>
         {map(filteredEntities, (elem, idx) => (
           <Entity
-            key={idx}
+            key={elem.id}
             entity={elem}
             handleEdit={this.handleEdit}
-            handleDelete={this.handleDelete}
+            handleDelete={this.handleDelete(elem.id)}
             highlightTerm={query}
           />
         ))}
@@ -103,7 +111,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      fetchEntities
+      fetchEntities,
+      deleteEntity
     },
     dispatch
   )

--- a/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
+++ b/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
@@ -33,7 +33,7 @@ class CurrentEntities extends Component {
   }
 
   filterEntities = (entities, query) => {
-    let filteredEntities = entities || [];
+    let filteredEntities = entities || []
 
     if (!isEmpty(query)) {
       const fieldMatcher = (field, query) => entity => {
@@ -57,7 +57,7 @@ class CurrentEntities extends Component {
         fieldsMatcher(fields, query)
       )
     }
-    return filteredEntities;
+    return filteredEntities
   }
 
   handleSearch = ev => {
@@ -67,13 +67,13 @@ class CurrentEntities extends Component {
     })
   }
 
-  handleEdit = (entity) => {
+  handleEdit = entity => {
     return () => {
-      this.props.editEntity({entity})
+      this.props.editEntity({ entity })
     }
   }
 
-  handleDelete = (id) => {
+  handleDelete = id => {
     return () => {
       this.props.deleteEntity(id)
     }

--- a/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
+++ b/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
@@ -69,7 +69,7 @@ class CurrentEntities extends Component {
 
   handleEdit = (entity) => {
     return () => {
-      this.props.editEntity({entity: entity})
+      this.props.editEntity({entity})
     }
   }
 

--- a/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
+++ b/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.jsx
@@ -8,6 +8,7 @@ import { isEmpty } from "../../../shared/utils/utilities"
 
 import Entity from "../Entity/Entity"
 import { fetchEntities, deleteEntity } from "../../actions/gameStateEditor"
+import { editEntity } from "../../../actions/app"
 
 class CurrentEntities extends Component {
   static propTypes = {
@@ -66,7 +67,11 @@ class CurrentEntities extends Component {
     })
   }
 
-  handleEdit = () => {}
+  handleEdit = (entity) => {
+    return () => {
+      this.props.editEntity({entity: entity})
+    }
+  }
 
   handleDelete = (id) => {
     return () => {
@@ -94,7 +99,7 @@ class CurrentEntities extends Component {
           <Entity
             key={elem.id}
             entity={elem}
-            handleEdit={this.handleEdit}
+            handleEdit={this.handleEdit(elem)}
             handleDelete={this.handleDelete(elem.id)}
             highlightTerm={query}
           />
@@ -112,7 +117,8 @@ const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
       fetchEntities,
-      deleteEntity
+      deleteEntity,
+      editEntity
     },
     dispatch
   )

--- a/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.test.js
+++ b/assets/js/react/GameStateEditor/components/CurrentEntities/CurrentEntities.test.js
@@ -24,8 +24,12 @@ describe("CurrentEntities", () => {
   describe("with entities", () => {
     let extraProps = {
       entities: [
-        { id: "ma", name: "man", name_tokens: ["m","a","n","spells", "man"] },
-        { id: "ya", name: "yan", name_tokens: ["y","a","n","spells", "yan"] }
+        {
+          id: "ma",
+          name: "man",
+          name_tokens: ["m", "a", "n", "spells", "man"]
+        },
+        { id: "ya", name: "yan", name_tokens: ["y", "a", "n", "spells", "yan"] }
       ]
     }
     beforeEach(() => {
@@ -35,16 +39,16 @@ describe("CurrentEntities", () => {
       expect(requiredProps.fetchEntities).not.toHaveBeenCalled()
     })
     it("renders each entity", () => {
-      expect(wrapper.find('Entity')).toHaveLength(2)
+      expect(wrapper.find("Entity")).toHaveLength(2)
     })
     it("allows search by name, id and highlights (with *) the matching term", () => {
-      const searchInput = wrapper.find('.CurrentEntities__search-input')
-      expect(wrapper.find('Entity')).toHaveLength(2)
-      searchInput.simulate('change', { target: { value: "ma" } } )
-      expect(wrapper.find('Entity')).toHaveLength(1)
+      const searchInput = wrapper.find(".CurrentEntities__search-input")
+      expect(wrapper.find("Entity")).toHaveLength(2)
+      searchInput.simulate("change", { target: { value: "ma" } })
+      expect(wrapper.find("Entity")).toHaveLength(1)
       expect(wrapper.text()).toContain("Matches: 1")
-      expect(wrapper.text()).toContain("\"*ma*n\"")
-      expect(wrapper.text()).toContain("\"*ma*\"")
-    });
+      expect(wrapper.text()).toContain('"*ma*n"')
+      expect(wrapper.text()).toContain('"*ma*"')
+    })
   })
 })

--- a/assets/js/react/GameStateEditor/components/Entity/Entity.css
+++ b/assets/js/react/GameStateEditor/components/Entity/Entity.css
@@ -3,6 +3,8 @@
 }
 
 .Entity pre {
+  font-size: smaller;
+  max-width: 100%;
   background-color: #fffcf3;
   border: 1px solid #eee;
 }

--- a/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
+++ b/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
@@ -12,16 +12,33 @@ const highlightedJsonObject = (entity, highlightTerm) => {
   }
 }
 
+const renderEditButton = (entity, handleEdit) => {
+  <button className="Entity__edit button" onClick={handleEdit}>
+    Edit
+  </button>
+}
+
+const renderDeleteButton = (entity, handleDelete) => {
+  if (entity.src !== null) {
+    return "";
+  }
+  return (
+    <button className="Entity__delete button" onClick={handleDelete} >
+      X
+    </button>
+  )
+};
+
 const Entity = ({ entity, handleEdit, handleDelete, highlightTerm }) => {
   return (
     <div className="Entity">
       <div className="Entity__actions">
-        <button className="Entity__edit button" onClick={handleEdit}>
-          Edit
-        </button>
-        <button className="Entity__delete button" onClick={handleDelete}>
-          X
-        </button>
+        {
+          renderEditButton(entity, handleEdit)
+        }
+        {
+          renderDeleteButton(entity, handleEdit)
+        }
       </div>
       <pre>
         <code>{highlightedJsonObject(entity, highlightTerm)}</code>

--- a/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
+++ b/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
@@ -12,11 +12,12 @@ const highlightedJsonObject = (entity, highlightTerm) => {
   }
 }
 
-const renderEditButton = (entity, handleEdit) => {
+const renderEditButton = (entity, handleEdit) => (
   <button className="Entity__edit button" onClick={handleEdit}>
     Edit
   </button>
-}
+)
+
 
 const renderDeleteButton = (entity, handleDelete) => {
   if (entity.src !== null) {

--- a/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
+++ b/assets/js/react/GameStateEditor/components/Entity/Entity.jsx
@@ -18,28 +18,23 @@ const renderEditButton = (entity, handleEdit) => (
   </button>
 )
 
-
 const renderDeleteButton = (entity, handleDelete) => {
-  if (entity.src !== null) {
-    return "";
+  if (entity.src) {
+    return ""
   }
   return (
-    <button className="Entity__delete button" onClick={handleDelete} >
+    <button className="Entity__delete button" onClick={handleDelete}>
       X
     </button>
   )
-};
+}
 
 const Entity = ({ entity, handleEdit, handleDelete, highlightTerm }) => {
   return (
     <div className="Entity">
       <div className="Entity__actions">
-        {
-          renderEditButton(entity, handleEdit)
-        }
-        {
-          renderDeleteButton(entity, handleEdit)
-        }
+        {renderEditButton(entity, handleEdit)}
+        {renderDeleteButton(entity, handleDelete)}
       </div>
       <pre>
         <code>{highlightedJsonObject(entity, highlightTerm)}</code>

--- a/assets/js/react/GameStateEditor/components/Entity/Entity.test.jsx
+++ b/assets/js/react/GameStateEditor/components/Entity/Entity.test.jsx
@@ -1,0 +1,54 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import { shallow, mount } from "enzyme"
+import Entity from "./Entity"
+
+describe("Entity", () => {
+  let wrapper
+  let extraProps
+  const handleEditSpy = jest.fn()
+  const handleDeleteSpy = jest.fn()
+  let requiredProps = {
+    handleEdit: handleEditSpy,
+    handleDelete: handleDeleteSpy,
+    entity: {
+      id: "thing",
+      name: "name"
+    }
+  }
+
+  beforeEach(() => {
+    handleEditSpy.mockReset()
+    handleDeleteSpy.mockReset()
+    wrapper = shallow(<Entity {...requiredProps} />)
+  })
+
+  it("calls handleDelete when you click the delete button", () => {
+    wrapper.find(".Entity__delete").simulate("click")
+    expect(requiredProps.handleDelete).toHaveBeenCalled()
+  })
+
+  it("calls handleEdit when you click the edit button", () => {
+    wrapper.find(".Entity__edit.button").simulate("click")
+    expect(requiredProps.handleEdit).toHaveBeenCalled()
+  })
+
+  describe("if the entity.src is populated", () => {
+    beforeEach(() => {
+      requiredProps = {
+        handleEdit: handleEditSpy,
+        handleDelete: handleDeleteSpy,
+        entity: {
+          id: "thing",
+          name: "name",
+          src: "priv_file://world.json"
+        }
+      }
+      wrapper = shallow(<Entity {...requiredProps} />)
+    })
+
+    it("does not show a delete button", () => {
+      expect(wrapper.find(".Entity__delete.button")).toHaveLength(0)
+    })
+  })
+})

--- a/assets/js/react/GameStateEditor/components/EntityForm/EntityForm.jsx
+++ b/assets/js/react/GameStateEditor/components/EntityForm/EntityForm.jsx
@@ -19,7 +19,7 @@ const emptyEntity = {
   id: "",
   name: "",
   props: {},
-  behaviors: { visible: { description: "" } },
+  behaviors: { visible: { description: "" } }
 }
 
 /** local helpers */
@@ -41,7 +41,7 @@ class EntityForm extends Component {
     fetchAvailableBehaviors: PropTypes.func.isRequired,
     addEntity: PropTypes.func.isRequired,
     entity: PropTypes.object,
-    editStarted: PropTypes.instanceOf(Date),
+    editStarted: PropTypes.instanceOf(Date)
   }
 
   static defaultProps = {
@@ -65,7 +65,9 @@ class EntityForm extends Component {
     if (loading || isEmpty(availableBehaviors) || isEmpty(behaviorShapes)) {
       return <Spinner />
     }
-    return <_EntityForm {...this.props} key={ (entity && entity.id) || "newEntity"} />
+    return (
+      <_EntityForm {...this.props} key={(entity && entity.id) || "newEntity"} />
+    )
   }
 }
 
@@ -84,7 +86,7 @@ class _EntityForm extends Component {
   handleRemoveBehavior = ev => {
     const currentState = this.state
     this.setState({
-      behaviors: omit([ev.target.name], this.state.behaviors),
+      behaviors: omit([ev.target.name], this.state.behaviors)
     })
   }
 
@@ -92,7 +94,7 @@ class _EntityForm extends Component {
     const currentState = this.state
     this.setState(
       mergeDeepRight(currentState, {
-        behaviors: { [selectedOption.value]: {} },
+        behaviors: { [selectedOption.value]: {} }
       })
     )
   }
@@ -151,7 +153,7 @@ class _EntityForm extends Component {
     if (fieldName.match(/\.destinationId$/)) {
       return {
         fieldType: "destination",
-        changeCallback: this.handleChangeDestination(fieldName),
+        changeCallback: this.handleChangeDestination(fieldName)
       }
     }
     return { fieldType: "text", changeCallback: this.handleChange }
@@ -330,7 +332,8 @@ class _EntityForm extends Component {
           </button>
           <button
             onClick={this.handleClear}
-            className="button EntityForm__clear-entity">
+            className="button EntityForm__clear-entity"
+          >
             Clear
           </button>
         </div>

--- a/assets/js/react/GameStateEditor/components/EntityForm/EntityForm.test.js
+++ b/assets/js/react/GameStateEditor/components/EntityForm/EntityForm.test.js
@@ -17,7 +17,7 @@ describe("EntityForm", () => {
   })
   describe("with the minimum props", () => {
     beforeEach(() => {
-      wrapper = shallow(<EntityForm {...requiredProps}/>)
+      wrapper = shallow(<EntityForm {...requiredProps} />)
     })
 
     it("renders without crashing", () => {
@@ -25,7 +25,7 @@ describe("EntityForm", () => {
       expect(wrapper.find("Spinner")).toHaveLength(1)
     })
     it("triggers the fetch behaviors action", () => {
-      expect(requiredProps.fetchAvailableBehaviors).toHaveBeenCalled();
+      expect(requiredProps.fetchAvailableBehaviors).toHaveBeenCalled()
     })
   })
 
@@ -39,7 +39,7 @@ describe("EntityForm", () => {
           visible: { description: "" }
         }
       }
-      wrapper = mount(<EntityForm {...requiredProps} {...extraProps}/>)
+      wrapper = mount(<EntityForm {...requiredProps} {...extraProps} />)
     })
 
     it("renders an empty form", () => {
@@ -51,11 +51,13 @@ describe("EntityForm", () => {
 
     it("renders an visible by default form", () => {
       expect(wrapper.find(".EntityForm").text()).toContain("Behavior: visible")
-      expect(wrapper.find(".EntityForm").text()).toContain("visible: description")
+      expect(wrapper.find(".EntityForm").text()).toContain(
+        "visible: description"
+      )
     })
 
     it("does not the fetch behaviors action", () => {
-      expect(requiredProps.fetchAvailableBehaviors).not.toHaveBeenCalled();
+      expect(requiredProps.fetchAvailableBehaviors).not.toHaveBeenCalled()
     })
   })
 
@@ -69,31 +71,34 @@ describe("EntityForm", () => {
           visible: { description: "" }
         },
         entity: {
-          id: 'whatever',
-          name: 'what ever',
+          id: "whatever",
+          name: "what ever",
           props: { location: "start" },
           behaviors: {
             visible: {
               description: "is a shiny blob"
             },
-            portable: {
-
-            }
+            portable: {}
           }
         }
       }
-      wrapper = mount(<EntityForm {...requiredProps} {...extraProps}/>)
+      wrapper = mount(<EntityForm {...requiredProps} {...extraProps} />)
     })
 
     it("does not the fetch behaviors action", () => {
-      expect(requiredProps.fetchAvailableBehaviors).not.toHaveBeenCalled();
+      expect(requiredProps.fetchAvailableBehaviors).not.toHaveBeenCalled()
     })
 
     it("renders all behaviors and associated form fields", () => {
       const formAsText = wrapper.find(".EntityForm").text()
-      expect(wrapper.find("input[name='name']").props().value).toEqual("what ever")
+      expect(wrapper.find("input[name='name']").props().value).toEqual(
+        "what ever"
+      )
       expect(wrapper.find("input[name='id']").props().value).toEqual("whatever")
-      expect(wrapper.find("input[name='behaviors.visible.description']").props().value).toEqual("is a shiny blob")
+      expect(
+        wrapper.find("input[name='behaviors.visible.description']").props()
+          .value
+      ).toEqual("is a shiny blob")
       expect(formAsText).toContain("Behavior: visible")
       expect(formAsText).toContain("visible: description")
       expect(formAsText).toContain("Behavior: portable")
@@ -101,35 +106,36 @@ describe("EntityForm", () => {
     })
 
     it("clicking on clear clears the entity", () => {
-      wrapper.find(".EntityForm__clear-entity").simulate('click')
+      wrapper.find(".EntityForm__clear-entity").simulate("click")
 
       const formAsText = wrapper.find(".EntityForm").text()
       expect(wrapper.find("input[name='name']").props().value).toEqual("")
       expect(wrapper.find("input[name='id']").props().value).toEqual("")
-      expect(wrapper.find("input[name='behaviors.visible.description']").props().value).toEqual("")
+      expect(
+        wrapper.find("input[name='behaviors.visible.description']").props()
+          .value
+      ).toEqual("")
       expect(formAsText).toContain("Behavior: visible")
       expect(formAsText).toContain("visible: description")
       expect(formAsText).not.toContain("Behavior: portable")
     })
 
     it("clicking on add submits the entity", () => {
-      wrapper.find(".EntityForm__submit-entity").simulate('click')
+      wrapper.find(".EntityForm__submit-entity").simulate("click")
 
-      expect(requiredProps.addEntity).toHaveBeenCalledWith(
-        {
-          id: "whatever",
-          name: "what ever",
-          props: {
-            location: "start"
+      expect(requiredProps.addEntity).toHaveBeenCalledWith({
+        id: "whatever",
+        name: "what ever",
+        props: {
+          location: "start"
+        },
+        behaviors: {
+          visible: {
+            description: "is a shiny blob"
           },
-          behaviors: {
-            visible: {
-              description: "is a shiny blob"
-            },
-            portable: { }
-          }
+          portable: {}
         }
-      );
+      })
     })
   })
 })

--- a/assets/js/react/GameStateEditor/reducers/entityForm.js
+++ b/assets/js/react/GameStateEditor/reducers/entityForm.js
@@ -8,7 +8,11 @@ import {
   ADD_ENTITY_SUCCESS,
   ADD_ENTITY_FAILURE
 } from "../actions/entityForm"
-import { EDIT_ENTITY, CLOSE_EDIT_PANE } from "../../actions/app"
+import {
+  EDIT_ENTITY,
+  CLOSE_EDIT_PANE
+} from "../../actions/app"
+
 import { convertBehaviorsToHash } from "../selectors"
 
 export const defaultState = {
@@ -24,7 +28,8 @@ export default function(state = defaultState, action) {
 
     case EDIT_ENTITY:
       if (data) {
-        const entity = omit("src", convertBehaviorsToHash(data.body.data.entity))
+        let entity = data.entity || data.body.data.entity;
+        entity = omit("src", convertBehaviorsToHash(entity))
         return mergeDeepRight(state, { entity, editStarted: new Date() })
       }
       return state

--- a/assets/js/react/GameStateEditor/reducers/entityForm.js
+++ b/assets/js/react/GameStateEditor/reducers/entityForm.js
@@ -29,7 +29,7 @@ export default function(state = defaultState, action) {
     case EDIT_ENTITY:
       if (data) {
         let entity = data.entity || data.body.data.entity;
-        entity = omit("src", convertBehaviorsToHash(entity))
+        entity = omit(["src"], convertBehaviorsToHash(entity))
         return mergeDeepRight(state, { entity, editStarted: new Date() })
       }
       return state

--- a/assets/js/react/GameStateEditor/reducers/entityForm.js
+++ b/assets/js/react/GameStateEditor/reducers/entityForm.js
@@ -8,10 +8,7 @@ import {
   ADD_ENTITY_SUCCESS,
   ADD_ENTITY_FAILURE
 } from "../actions/entityForm"
-import {
-  EDIT_ENTITY,
-  CLOSE_EDIT_PANE
-} from "../../actions/app"
+import { EDIT_ENTITY, CLOSE_EDIT_PANE } from "../../actions/app"
 
 import { convertBehaviorsToHash } from "../selectors"
 
@@ -28,7 +25,7 @@ export default function(state = defaultState, action) {
 
     case EDIT_ENTITY:
       if (data) {
-        let entity = data.entity || data.body.data.entity;
+        let entity = data.entity || data.body.data.entity
         entity = omit(["src"], convertBehaviorsToHash(entity))
         return mergeDeepRight(state, { entity, editStarted: new Date() })
       }
@@ -42,13 +39,13 @@ export default function(state = defaultState, action) {
     case ADD_ENTITY_SUCCESS:
       return mergeDeepRight(state, {
         entity: data.entity,
-        loading: false,
+        loading: false
       })
     case FETCH_AVAILABLE_BEHAVIORS_SUCCESS:
       return mergeDeepRight(state, {
         availableBehaviors: data.behaviors,
         behaviorShapes: data.behaviorShapes,
-        loading: false,
+        loading: false
       })
     case ADD_ENTITY_FAILURE:
     case FETCH_AVAILABLE_BEHAVIORS_FAILURE:

--- a/assets/js/react/GameStateEditor/reducers/entityForm.test.js
+++ b/assets/js/react/GameStateEditor/reducers/entityForm.test.js
@@ -6,11 +6,9 @@ import {
   addEntitySuccess,
   fetchAvailableBehaviorsSuccess,
   addEntityFailure,
-  fetchAvailableBehaviorsFailure,
+  fetchAvailableBehaviorsFailure
 } from "../actions/entityForm"
-import {
-  editEntity
-} from "../../actions/app.js"
+import { editEntity } from "../../actions/app.js"
 
 describe("entityForm.reducer", () => {
   it("has a default state", () => {
@@ -18,43 +16,39 @@ describe("entityForm.reducer", () => {
     expect(state).toEqual(defaultState)
   })
 
-    // case EDIT_ENTITY:
-    //   if (data) {
-    //     let entity = data.entity || data.body.data.entity;
-    //     entity = omit("src", convertBehaviorsToHash(entity))
-    //     return mergeDeepRight(state, { entity, editStarted: new Date() })
-    //   }
-    //   return state
-
-  const entity = {
-    src: "somewhere",
-    id: "the-rock",
-    name: "Dwayne Johnson",
-    proto: "_player",
-    props: {
-      location: "room"
-    },
-    behaviors: [
-      {
-        type: "visible",
-        description: "is the biggest superstar in the history of WWE"
-      }
-    ]
-  }
-
   describe("EDIT_ENTITY", () => {
+    const entity = {
+      src: "somewhere",
+      id: "the-rock",
+      name: "Dwayne Johnson",
+      proto: "_player",
+      props: {
+        location: "room"
+      },
+      behaviors: [
+        {
+          type: "visible",
+          description: "is the biggest superstar in the history of WWE"
+        }
+      ]
+    }
+
     it("sets the entity if it comes from the phoenix side (data.body.data.entity)", () => {
-      const state = reducer({}, editEntity( { body: { data: { entity }}}))
-      expect(state.entity.behaviors).toEqual({visible: { description: "is the biggest superstar in the history of WWE"}})
+      const state = reducer({}, editEntity({ body: { data: { entity } } }))
+      expect(state.entity.behaviors).toEqual({
+        visible: {
+          description: "is the biggest superstar in the history of WWE"
+        }
+      })
       expect(state.editStarted).toBeTruthy()
     })
     it("sets the entity if it comes from the editor side (data.entity)", () => {
-      const state = reducer({}, editEntity( { entity }))
+      const state = reducer({}, editEntity({ entity }))
       expect(state.entity).toBeTruthy()
       expect(state.editStarted).toBeTruthy()
     })
     it("removes the `src` value from entity before putting it in the store", () => {
-      const state = reducer({}, editEntity( { entity }))
+      const state = reducer({}, editEntity({ entity }))
       expect(state.entity.src).toEqual(undefined)
     })
   })

--- a/assets/js/react/GameStateEditor/reducers/entityForm.test.js
+++ b/assets/js/react/GameStateEditor/reducers/entityForm.test.js
@@ -8,6 +8,9 @@ import {
   addEntityFailure,
   fetchAvailableBehaviorsFailure,
 } from "../actions/entityForm"
+import {
+  editEntity
+} from "../../actions/app.js"
 
 describe("entityForm.reducer", () => {
   it("has a default state", () => {
@@ -15,6 +18,46 @@ describe("entityForm.reducer", () => {
     expect(state).toEqual(defaultState)
   })
 
+    // case EDIT_ENTITY:
+    //   if (data) {
+    //     let entity = data.entity || data.body.data.entity;
+    //     entity = omit("src", convertBehaviorsToHash(entity))
+    //     return mergeDeepRight(state, { entity, editStarted: new Date() })
+    //   }
+    //   return state
+
+  const entity = {
+    src: "somewhere",
+    id: "the-rock",
+    name: "Dwayne Johnson",
+    proto: "_player",
+    props: {
+      location: "room"
+    },
+    behaviors: [
+      {
+        type: "visible",
+        description: "is the biggest superstar in the history of WWE"
+      }
+    ]
+  }
+
+  describe("EDIT_ENTITY", () => {
+    it("sets the entity if it comes from the phoenix side (data.body.data.entity)", () => {
+      const state = reducer({}, editEntity( { body: { data: { entity }}}))
+      expect(state.entity.behaviors).toEqual({visible: { description: "is the biggest superstar in the history of WWE"}})
+      expect(state.editStarted).toBeTruthy()
+    })
+    it("sets the entity if it comes from the editor side (data.entity)", () => {
+      const state = reducer({}, editEntity( { entity }))
+      expect(state.entity).toBeTruthy()
+      expect(state.editStarted).toBeTruthy()
+    })
+    it("removes the `src` value from entity before putting it in the store", () => {
+      const state = reducer({}, editEntity( { entity }))
+      expect(state.entity.src).toEqual(undefined)
+    })
+  })
   describe("ADD_ENTITY", () => {
     it("sets loading true", () => {
       const state = reducer({}, addEntity({}))

--- a/assets/js/react/GameStateEditor/reducers/gameStateEditor.js
+++ b/assets/js/react/GameStateEditor/reducers/gameStateEditor.js
@@ -2,16 +2,24 @@ import { mergeDeepRight } from "ramda"
 import {
   FETCH_ENTITIES,
   FETCH_ENTITIES_SUCCESS,
-  FETCH_ENTITIES_FAILURE
+  FETCH_ENTITIES_FAILURE,
 } from "../actions/gameStateEditor"
+import {
+  EDIT_ENTITY
+} from "../../actions/app"
+
 import { extractLocationsFromEntities } from "../selectors"
 
 export const defaultState = {
-  entities: []
+  entities: [],
+  activeTab: null,
+  loading: false
 }
 
 export default function(state = defaultState, action) {
   switch (action.type) {
+  case EDIT_ENTITY:
+      return mergeDeepRight(state, { activeTab: "Editor" });
     case FETCH_ENTITIES:
       return mergeDeepRight(state, {
         loading: true

--- a/assets/js/react/GameStateEditor/reducers/gameStateEditor.js
+++ b/assets/js/react/GameStateEditor/reducers/gameStateEditor.js
@@ -2,11 +2,9 @@ import { mergeDeepRight } from "ramda"
 import {
   FETCH_ENTITIES,
   FETCH_ENTITIES_SUCCESS,
-  FETCH_ENTITIES_FAILURE,
+  FETCH_ENTITIES_FAILURE
 } from "../actions/gameStateEditor"
-import {
-  EDIT_ENTITY
-} from "../../actions/app"
+import { EDIT_ENTITY } from "../../actions/app"
 
 import { extractLocationsFromEntities } from "../selectors"
 
@@ -18,8 +16,8 @@ export const defaultState = {
 
 export default function(state = defaultState, action) {
   switch (action.type) {
-  case EDIT_ENTITY:
-      return mergeDeepRight(state, { activeTab: "Editor" });
+    case EDIT_ENTITY:
+      return mergeDeepRight(state, { activeTab: "Editor" })
     case FETCH_ENTITIES:
       return mergeDeepRight(state, {
         loading: true

--- a/assets/js/react/GameStateEditor/reducers/gameStateEditor.test.js
+++ b/assets/js/react/GameStateEditor/reducers/gameStateEditor.test.js
@@ -3,13 +3,13 @@ import reducer, { defaultState } from "./gameStateEditor"
 import {
   fetchEntities,
   fetchEntitiesSuccess,
-  fetchEntitiesFailure,
+  fetchEntitiesFailure
 } from "../actions/gameStateEditor"
 
 describe("gameStateEditor.reducer", () => {
   const entities = [
     { id: "a-location", name: "a location" },
-    { id: "not-a-location", props: { location: "a-location" }}
+    { id: "not-a-location", props: { location: "a-location" } }
   ]
 
   it("has a default state", () => {

--- a/assets/js/react/GameStateEditor/sagas/addEntitySaga.js
+++ b/assets/js/react/GameStateEditor/sagas/addEntitySaga.js
@@ -32,7 +32,7 @@ function* add(action) {
     yield put(
       addFlashMessage({
         type: "error",
-        text: `Failed to add entity: ${JSON.stringify(e.response.data)}`,
+        text: `Failed to add entity: ${JSON.stringify(e.response.data)}`
       })
     )
   }

--- a/assets/js/react/GameStateEditor/sagas/deleteEntitySaga.js
+++ b/assets/js/react/GameStateEditor/sagas/deleteEntitySaga.js
@@ -1,0 +1,42 @@
+import "regenerator-runtime/runtime"
+import { takeLatest, put, call } from "redux-saga/effects"
+
+import {
+  DELETE_ENTITY,
+  deleteEntitySuccess,
+  deleteEntityFailure
+} from "../actions/gameStateEditor"
+
+import { addFlashMessage } from "../../shared/actions/flashMessage"
+import { fetchEntities } from "../actions/gameStateEditor"
+
+import api from "../../api"
+
+function* removeEntity(action) {
+  console.log("REMOVE", action)
+  try {
+    const id = action.data;
+    const response = yield call(api.entities.destroy(id))
+    yield put(deleteEntitySuccess(response.data))
+    yield put(
+      addFlashMessage({
+        type: "info",
+        text: `Success: ${JSON.stringify(response.data.message)}`
+      })
+    )
+    yield put(fetchEntities())
+  } catch (e) {
+    console.error("Entity not removed", e)
+    yield put(deleteEntityFailure(e.response.data))
+    yield put(
+      addFlashMessage({
+        type: "error",
+        text: `Failed to remove entity: ${JSON.stringify(e.response.data)}`,
+      })
+    )
+  }
+}
+
+export default function* onDeleteEntity() {
+  yield takeLatest(DELETE_ENTITY, removeEntity)
+}

--- a/assets/js/react/GameStateEditor/sagas/deleteEntitySaga.js
+++ b/assets/js/react/GameStateEditor/sagas/deleteEntitySaga.js
@@ -15,7 +15,7 @@ import api from "../../api"
 function* removeEntity(action) {
   console.log("REMOVE", action)
   try {
-    const id = action.data;
+    const id = action.data
     const response = yield call(api.entities.destroy(id))
     yield put(deleteEntitySuccess(response.data))
     yield put(
@@ -31,7 +31,7 @@ function* removeEntity(action) {
     yield put(
       addFlashMessage({
         type: "error",
-        text: `Failed to remove entity: ${JSON.stringify(e.response.data)}`,
+        text: `Failed to remove entity: ${JSON.stringify(e.response.data)}`
       })
     )
   }

--- a/assets/js/react/GameStateEditor/sagas/downloadEntitiesSaga.js
+++ b/assets/js/react/GameStateEditor/sagas/downloadEntitiesSaga.js
@@ -2,27 +2,25 @@ import "regenerator-runtime/runtime"
 import { takeLatest, put, call, spawn } from "redux-saga/effects"
 import download from "downloadjs"
 
-import {
-  DOWNLOAD_ENTITIES
-} from "../actions/gameStateEditor"
+import { DOWNLOAD_ENTITIES } from "../actions/gameStateEditor"
 
 import api from "../../api"
 
 const _downloadEntities = (entities, filename) => {
-  return () => download(
-    JSON.stringify({entities: entities}),
-    filename,
-    "application/json"
-  )
-};
+  return () =>
+    download(
+      JSON.stringify({ entities: entities }),
+      filename,
+      "application/json"
+    )
+}
 
 function* downloadEntities(action) {
   try {
     const entities = action.data.entities
     const filename = action.data.filename || "entities.json"
     yield call(_downloadEntities(entities, filename))
-  } catch (e) {
-  }
+  } catch (e) {}
 }
 
 export default function* onDownloadEntities() {

--- a/assets/js/react/GameStateEditor/selectors/index.js
+++ b/assets/js/react/GameStateEditor/selectors/index.js
@@ -36,7 +36,7 @@ export const convertBehaviorsToArray = entity => {
   if (!isEmpty(entity.behaviors)) {
     behaviors = map(entity.behaviors || {}, (behaviorProps, key) => ({
       type: key,
-      ...behaviorProps,
+      ...behaviorProps
     }))
   }
   return { ...entity, behaviors }

--- a/assets/js/react/GameStateEditor/selectors/index.test.js
+++ b/assets/js/react/GameStateEditor/selectors/index.test.js
@@ -9,16 +9,14 @@ describe("extractLocationsFromEntities", () => {
   let entities = [
     {
       props: {},
-      name_tokens: [
-        'sidewalk'
-      ],
-      name: 'sidewalk',
-      id: 'sidewalk',
+      name_tokens: ["sidewalk"],
+      name: "sidewalk",
+      id: "sidewalk",
       behaviors: [
         {
-          type: 'visible',
+          type: "visible",
           own: true,
-          description: 'You are on a sidewalk.'
+          description: "You are on a sidewalk."
         }
       ]
     },
@@ -27,50 +25,44 @@ describe("extractLocationsFromEntities", () => {
     },
     {
       props: {
-        location: 'bathroom'
+        location: "bathroom"
       },
-      name_tokens: [
-        'machine',
-        'sewing',
-        'sewing machine'
-      ],
-      name: 'sewing machine',
-      id: 'juki',
+      name_tokens: ["machine", "sewing", "sewing machine"],
+      name: "sewing machine",
+      id: "juki",
       behaviors: [
         {
-          type: 'visible',
-          description: 'is a Juki DNU-1541, threaded with some #69 bonded nylon.'
+          type: "visible",
+          description:
+            "is a Juki DNU-1541, threaded with some #69 bonded nylon."
         }
       ]
     },
     {
       props: {
-        location: 'start'
+        location: "start"
       },
-      name_tokens: [
-        'open',
-        'open window',
-        'window'
-      ],
-      name: 'open window',
-      id: 'office-fire_escape-door',
+      name_tokens: ["open", "open window", "window"],
+      name: "open window",
+      id: "office-fire_escape-door",
       behaviors: [
         {
-          type: 'exit',
+          type: "exit",
           own: true,
-          destination_id: 'fire_escape'
+          destination_id: "fire_escape"
         },
         {
-          type: 'visible',
+          type: "visible",
           own: true,
-          description: 'is a small fire escape that looks like a fire hazard itself.'
+          description:
+            "is a small fire escape that looks like a fire hazard itself."
         }
       ]
-    },
+    }
   ]
 
   it("extracts locations from entities", () => {
-    expect( extractLocationsFromEntities(entities) ).toEqual(["sidewalk"])
+    expect(extractLocationsFromEntities(entities)).toEqual(["sidewalk"])
   })
 })
 
@@ -81,22 +73,22 @@ describe("convertBehaviorsToArray", () => {
       name: "the thing",
       behaviors: {
         visible: { description: "is the thing's description" },
-        god: {},
-      },
+        god: {}
+      }
     })
     expect(repacked).toEqual({
       id: "the-thing",
       name: "the thing",
       behaviors: [
         { type: "visible", description: "is the thing's description" },
-        { type: "god" },
-      ],
+        { type: "god" }
+      ]
     })
   })
   it("handles empty behaviors properly", () => {
     expect(convertBehaviorsToArray({})).toEqual({})
     expect(convertBehaviorsToArray({ behaviors: {} })).toEqual({
-      behaviors: [],
+      behaviors: []
     })
   })
 })
@@ -108,22 +100,22 @@ describe("convertBehaviorsToHash", () => {
       name: "the thing",
       behaviors: [
         { type: "visible", description: "is the thing's description" },
-        { type: "god" },
-      ],
+        { type: "god" }
+      ]
     })
     expect(repacked).toEqual({
       id: "the-thing",
       name: "the thing",
       behaviors: {
         visible: { description: "is the thing's description" },
-        god: {},
-      },
+        god: {}
+      }
     })
   })
   it("handles empty behaviors properly", () => {
     expect(convertBehaviorsToHash({})).toEqual({})
     expect(convertBehaviorsToHash({ behaviors: [] })).toEqual({
-      behaviors: {},
+      behaviors: {}
     })
   })
 })

--- a/assets/js/react/api.js
+++ b/assets/js/react/api.js
@@ -8,7 +8,7 @@ const api = {
   entities: {
     index: () => get("/api/entities"),
     create: data => put("/api/entities", data),
-    destroy: (id) => () => del(`/api/entities/${id}`)
+    destroy: id => () => del(`/api/entities/${id}`)
   }
 }
 

--- a/assets/js/react/api.js
+++ b/assets/js/react/api.js
@@ -1,5 +1,5 @@
 /** Identify and Expose API endpoints available for React/Redux/Sagas */
-import { get, put } from "./services/api"
+import { get, put, destroy as del } from "./services/api"
 
 const api = {
   behaviors: {
@@ -7,7 +7,8 @@ const api = {
   },
   entities: {
     index: () => get("/api/entities"),
-    create: data => put("/api/entities", data)
+    create: data => put("/api/entities", data),
+    destroy: (id) => () => del(`/api/entities/${id}`)
   }
 }
 

--- a/assets/js/react/reducers/index.js
+++ b/assets/js/react/reducers/index.js
@@ -1,14 +1,17 @@
 import { combineReducers } from "redux"
+
 import app from "./app.js"
 import entityForm from "../GameStateEditor/reducers/entityForm"
-import gameStateEditor from "../GameStateEditor/reducers/gameStateEditor"
 import flashMessage from "../shared/reducers/flashMessage"
+import gameStateEditor from "../GameStateEditor/reducers/gameStateEditor"
+import tabs from "../shared/reducers/tabs"
 import userSession from "../shared/reducers/userSession"
 
 export default combineReducers({
   app,
   entityForm,
-  gameStateEditor,
   flashMessage,
+  gameStateEditor,
+  tabs,
   userSession
 })

--- a/assets/js/react/sagas/index.js
+++ b/assets/js/react/sagas/index.js
@@ -2,12 +2,14 @@ import fetchAvailableBehaviorsSaga from "../GameStateEditor/sagas/fetchAvailable
 import fetchEntitiesSaga from "../GameStateEditor/sagas/fetchEntitiesSaga"
 import downloadEntitiesSaga from "../GameStateEditor/sagas/downloadEntitiesSaga"
 import addEntitySaga from "../GameStateEditor/sagas/addEntitySaga"
+import deleteEntitySaga from "../GameStateEditor/sagas/deleteEntitySaga"
 import gameChannelSaga from "../shared/sagas/gameChannelSaga"
 
 export default [
   fetchAvailableBehaviorsSaga,
   fetchEntitiesSaga,
   downloadEntitiesSaga,
+  deleteEntitySaga,
   addEntitySaga,
   gameChannelSaga
 ]

--- a/assets/js/react/shared/actions/tabs.js
+++ b/assets/js/react/shared/actions/tabs.js
@@ -1,0 +1,3 @@
+export const ACTIVATE_TAB = "tabs/ACTIVATE_TAB"
+
+export const activateTab = data => ({ type: ACTIVATE_TAB, data })

--- a/assets/js/react/shared/components/Flash/Flash.test.js
+++ b/assets/js/react/shared/components/Flash/Flash.test.js
@@ -22,5 +22,4 @@ describe("Flash", () => {
     expect(wrapper.find(".Flash__message").text()).toContain("the message")
     expect(wrapper.find(".Flash__close-button")).toHaveLength(1)
   })
-
 })

--- a/assets/js/react/shared/components/TabSet/TabSet.jsx
+++ b/assets/js/react/shared/components/TabSet/TabSet.jsx
@@ -19,7 +19,7 @@ class TabSet extends Component {
   }
 
   static defaultProps = {
-    activeTab: "Editor"
+    activeTab: ""
   }
 
   constructor(props) {
@@ -32,9 +32,13 @@ class TabSet extends Component {
 
   render() {
     const { className, tabs, buttonListClassName } = this.props
-    const active = this.props.activeTab;
+    if (!tabs.length) {
+      return "";
+    }
+
+    let active = this.props.activeTab;
     if (!active) {
-      return null;
+      active = tabs[0].name;
     }
     const theActiveTab = activeTab(active, tabs)
     const theActiveTabInfo = activeTabInfo(active, tabs)

--- a/assets/js/react/shared/components/TabSet/TabSet.jsx
+++ b/assets/js/react/shared/components/TabSet/TabSet.jsx
@@ -1,26 +1,41 @@
 import React, { Component } from "react"
 import PropTypes from "prop-types"
+import { connect } from "react-redux"
+import { bindActionCreators } from "redux"
 import classnames from "classnames"
 
 import TabSetButtonList from "./TabSetButtonList"
 import { tabSetType, activeTab, activeTabInfo } from "../tab"
+import { activateTab } from "../../actions/tabs.js"
 
 class TabSet extends Component {
+
+  static propTypes = {
+    className: PropTypes.string,
+    tabs: tabSetType.isRequired,
+    activeTab: PropTypes.string,
+    buttonListClassName: PropTypes.string,
+    activateTab: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    activeTab: "Editor"
+  }
+
   constructor(props) {
     super(props)
 
     const { tabs } = this.props
-
-    this.state = {
-      active: tabs[0].name
-    }
   }
 
-  handleButtonClick = tabName => this.setState({ active: tabName })
+  handleButtonClick = tabName => this.props.activateTab(tabName)
 
   render() {
     const { className, tabs, buttonListClassName } = this.props
-    const { active } = this.state
+    const active = this.props.activeTab;
+    if (!active) {
+      return null;
+    }
     const theActiveTab = activeTab(active, tabs)
     const theActiveTabInfo = activeTabInfo(active, tabs)
     return (
@@ -42,10 +57,22 @@ class TabSet extends Component {
   }
 }
 
-TabSet.propTypes = {
-  className: PropTypes.string,
-  tabs: tabSetType.isRequired,
-  buttonListClassName: PropTypes.string
-}
+const mapStateToProps = state => ({
+  activeTab: state.tabs.activeTab,
+})
 
-export default TabSet
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      activateTab,
+    },
+    dispatch
+  )
+
+const connectedComponent = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TabSet)
+
+export { TabSet }
+export default connectedComponent

--- a/assets/js/react/shared/components/TabSet/TabSet.jsx
+++ b/assets/js/react/shared/components/TabSet/TabSet.jsx
@@ -9,7 +9,6 @@ import { tabSetType, activeTab, activeTabInfo } from "../tab"
 import { activateTab } from "../../actions/tabs.js"
 
 class TabSet extends Component {
-
   static propTypes = {
     className: PropTypes.string,
     tabs: tabSetType.isRequired,
@@ -33,12 +32,12 @@ class TabSet extends Component {
   render() {
     const { className, tabs, buttonListClassName } = this.props
     if (!tabs.length) {
-      return "";
+      return ""
     }
 
-    let active = this.props.activeTab;
+    let active = this.props.activeTab
     if (!active) {
-      active = tabs[0].name;
+      active = tabs[0].name
     }
     const theActiveTab = activeTab(active, tabs)
     const theActiveTabInfo = activeTabInfo(active, tabs)
@@ -62,13 +61,13 @@ class TabSet extends Component {
 }
 
 const mapStateToProps = state => ({
-  activeTab: state.tabs.activeTab,
+  activeTab: state.tabs.activeTab
 })
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      activateTab,
+      activateTab
     },
     dispatch
   )

--- a/assets/js/react/shared/components/TabSet/TabSet.test.jsx
+++ b/assets/js/react/shared/components/TabSet/TabSet.test.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { shallow } from "enzyme"
-import TabSet from "./TabSet"
+import { TabSet } from "./TabSet"
 
 const tabs = [
   { name: "First", component: <div className="first" /> },
@@ -8,7 +8,7 @@ const tabs = [
   { name: "Link", link: "https://example.com/somewhere" }
 ]
 
-const requiredProps = { tabs }
+const requiredProps = { tabs, activateTab: jest.fn() }
 
 describe("TabSet", () => {
   let wrapper
@@ -31,9 +31,10 @@ describe("TabSet", () => {
       expect(wrapper.find(".second")).toHaveLength(0)
     })
 
-    describe("given a click on the second tab button", () => {
+    describe("given the activeTab is 'Second' in props", () => {
       beforeEach(() => {
-        buttons.simulate("buttonClick", "Second")
+        props = { ...requiredProps, activeTab: "Second" }
+        wrapper = shallow(<TabSet {...props} />)
       })
 
       it("renders the second tab", () => {

--- a/assets/js/react/shared/reducers/tabs.js
+++ b/assets/js/react/shared/reducers/tabs.js
@@ -1,20 +1,15 @@
 import { mergeDeepRight } from "ramda"
-import {
-  ACTIVATE_TAB
-} from "../actions/tabs"
-import {
-  EDIT_ENTITY
-} from "../../actions/app"
+import { ACTIVATE_TAB } from "../actions/tabs"
+import { EDIT_ENTITY } from "../../actions/app"
 
-export const defaultState = {
-}
+export const defaultState = {}
 
 export default function(state = defaultState, action) {
   switch (action.type) {
     case EDIT_ENTITY:
-    return mergeDeepRight(state, { activeTab: "Editor" })
+      return mergeDeepRight(state, { activeTab: "Editor" })
     case ACTIVATE_TAB:
-    return mergeDeepRight(state, { activeTab: action.data })
+      return mergeDeepRight(state, { activeTab: action.data })
     default:
       return state
   }

--- a/assets/js/react/shared/reducers/tabs.js
+++ b/assets/js/react/shared/reducers/tabs.js
@@ -1,0 +1,21 @@
+import { mergeDeepRight } from "ramda"
+import {
+  ACTIVATE_TAB
+} from "../actions/tabs"
+import {
+  EDIT_ENTITY
+} from "../../actions/app"
+
+export const defaultState = {
+}
+
+export default function(state = defaultState, action) {
+  switch (action.type) {
+    case EDIT_ENTITY:
+    return mergeDeepRight(state, { activeTab: "Editor" })
+    case ACTIVATE_TAB:
+    return mergeDeepRight(state, { activeTab: action.data })
+    default:
+      return state
+  }
+}

--- a/assets/js/react/shared/reducers/tabs.test.js
+++ b/assets/js/react/shared/reducers/tabs.test.js
@@ -10,20 +10,14 @@ describe("tabs reducer", () => {
 
   describe("EDIT_ENTITY", () => {
     it("adds the message to the store", () => {
-      const state = reducer(
-        {},
-        editEntity({})
-      )
+      const state = reducer({}, editEntity({}))
       expect(state).toEqual({ activeTab: "Editor" })
     })
   })
 
   describe("ACTIVATE_TAB", () => {
     it("removes the flash message from the store", () => {
-      const state = reducer(
-        { activeTab: "Whatever" },
-        activateTab("newTab")
-      )
+      const state = reducer({ activeTab: "Whatever" }, activateTab("newTab"))
       expect(state).toEqual({ activeTab: "newTab" })
     })
   })

--- a/assets/js/react/shared/reducers/tabs.test.js
+++ b/assets/js/react/shared/reducers/tabs.test.js
@@ -1,0 +1,30 @@
+import reducer, { defaultState } from "./tabs"
+import { activateTab } from "../actions/tabs"
+import { editEntity } from "../../actions/app"
+
+describe("tabs reducer", () => {
+  it("has a default state", () => {
+    const state = reducer(undefined, {})
+    expect(state).toEqual(defaultState)
+  })
+
+  describe("EDIT_ENTITY", () => {
+    it("adds the message to the store", () => {
+      const state = reducer(
+        {},
+        editEntity({})
+      )
+      expect(state).toEqual({ activeTab: "Editor" })
+    })
+  })
+
+  describe("ACTIVATE_TAB", () => {
+    it("removes the flash message from the store", () => {
+      const state = reducer(
+        { activeTab: "Whatever" },
+        activateTab("newTab")
+      )
+      expect(state).toEqual({ activeTab: "newTab" })
+    })
+  })
+})

--- a/assets/js/react/shared/sagas/gameChannelSaga.js
+++ b/assets/js/react/shared/sagas/gameChannelSaga.js
@@ -47,7 +47,7 @@ function createCommandChannel(channel) {
   return eventChannel(emit => {
     const handleCustomEvents = ev => {
       const customEventAction = {
-        open_entity_editor: editEntity,
+        open_entity_editor: editEntity
       }[ev.body.data.type]
       if (customEventAction) {
         emit(customEventAction(ev))

--- a/assets/js/react/shared/utils/utilities.test.js
+++ b/assets/js/react/shared/utils/utilities.test.js
@@ -1,56 +1,55 @@
-import { isEmpty, isBlank } from "./utilities";
+import { isEmpty, isBlank } from "./utilities"
 
 describe("utilities", () => {
   describe("isEmpty", () => {
     it("returns false for an object with elements", () => {
-      expect(isEmpty({ a: 1 })).toBe(false);
-    });
+      expect(isEmpty({ a: 1 })).toBe(false)
+    })
 
     it("returns true for an empty object", () => {
-      expect(isEmpty({})).toBe(true);
-    });
+      expect(isEmpty({})).toBe(true)
+    })
 
     it("returns true for null", () => {
-      expect(isEmpty(null)).toBe(true);
-    });
+      expect(isEmpty(null)).toBe(true)
+    })
 
     it("returns true for undefined", () => {
-      expect(isEmpty(undefined)).toBe(true);
-    });
+      expect(isEmpty(undefined)).toBe(true)
+    })
 
     it("returns true for empty string", () => {
       expect(isEmpty("")).toBe(true)
-    });
+    })
 
     it("returns false for string of whitespace", () => {
       expect(isEmpty("  ")).toBe(false)
-    });
-  });
+    })
+  })
 
   describe("isBlank", () => {
     it("returns false for an object with elements", () => {
-      expect(isBlank({ a: 1 })).toBe(false);
-    });
+      expect(isBlank({ a: 1 })).toBe(false)
+    })
 
     it("returns true for an empty object", () => {
-      expect(isBlank({})).toBe(true);
-    });
+      expect(isBlank({})).toBe(true)
+    })
 
     it("returns true for null", () => {
-      expect(isBlank(null)).toBe(true);
-    });
+      expect(isBlank(null)).toBe(true)
+    })
 
     it("returns true for undefined", () => {
-      expect(isBlank(undefined)).toBe(true);
-    });
+      expect(isBlank(undefined)).toBe(true)
+    })
 
     it("returns true for empty string", () => {
       expect(isBlank("")).toBe(true)
-    });
+    })
 
     it("returns true for string of whitespace", () => {
       expect(isBlank("  ")).toBe(true)
-    });
-
-  });
-});
+    })
+  })
+})

--- a/lib/doro/behaviors/god.ex
+++ b/lib/doro/behaviors/god.ex
@@ -23,14 +23,13 @@ defmodule Doro.Behaviors.God do
   end
 
   interact_if("/edit", %{player: player, rest: rest}) do
-    found_entity = Doro.World.get_entities([in_location(player[:location]), named(rest)])
-    |> Enum.at(0)
+    found_entity = find_entity_in_location_or_location(player, rest)
     rest_present = (rest != nil) && (String.length(rest |> String.trim()) > 0)
     rest_present && found_entity
   end
 
   interact("/edit", %{player: player, rest: name}) do
-    entity = Doro.World.get_entities([in_location(player[:location]), named(name)]) |> Enum.at(0)
+    entity = find_entity_in_location_or_location(player, name)
     send_to_player(player,
       "You concentrate on #{definite(entity)}.  Nothing happens and you feel silly.",
       %{
@@ -38,5 +37,20 @@ defmodule Doro.Behaviors.God do
         "entity": entity |> Doro.World.Marshal.marshal
       }
     )
+  end
+
+  defp find_entity_in_location_or_location(player, rest) do
+    found_entity = Doro.World.get_entities([in_location(player[:location]), named(rest)])
+    |> Enum.at(0)
+    # try location if we couldn't find the thing in the location
+    case found_entity do
+      nil ->
+        location = Doro.World.get_entity(player[:location])
+        case location |> named(rest).() do
+          false -> nil
+          _ -> location
+        end
+      _ -> found_entity
+    end
   end
 end

--- a/lib/doro/behaviors/god.ex
+++ b/lib/doro/behaviors/god.ex
@@ -42,7 +42,6 @@ defmodule Doro.Behaviors.God do
   defp find_entity_in_location_or_location(player, rest) do
     found_entity = Doro.World.get_entities([in_location(player[:location]), named(rest)])
     |> Enum.at(0)
-    # try location if we couldn't find the thing in the location
     case found_entity do
       nil ->
         location = Doro.World.get_entity(player[:location])

--- a/lib/doro/world/game_state.ex
+++ b/lib/doro/world/game_state.ex
@@ -1,7 +1,14 @@
 defmodule Doro.World.GameState do
   use GenServer
 
+  alias Doro.Entity
+
   @table_name :entities
+
+  def set(new_state) do
+    # TODO this appears to only be used in tests... do we still need it
+    GenServer.call(__MODULE__, {:set_entities, new_state.entities})
+  end
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -9,10 +16,6 @@ defmodule Doro.World.GameState do
 
   def clear do
     GenServer.call(__MODULE__, :clear)
-  end
-
-  def set(new_state) do
-    GenServer.call(__MODULE__, {:set_entities, new_state.entities})
   end
 
   def get, do: all_entities()
@@ -35,13 +38,17 @@ defmodule Doro.World.GameState do
     GenServer.call(__MODULE__, {:set_entity_prop, entity_id, key, value})
   end
 
-  def add_entity(entity = %Doro.Entity{}) do
+  def add_entity(entity = %Entity{}) do
     add_entities([entity])
     entity
   end
 
   def add_entities(entities) do
     GenServer.call(__MODULE__, {:insert_entities, entities})
+  end
+
+  def remove_entity(entity = %Entity{}) do
+    set(%{entities: get_entities(fn e -> e.id != entity.id end)})
   end
 
   defp all_entities do

--- a/lib/doro/world/game_state.ex
+++ b/lib/doro/world/game_state.ex
@@ -6,7 +6,6 @@ defmodule Doro.World.GameState do
   @table_name :entities
 
   def set(new_state) do
-    # TODO this appears to only be used in tests... do we still need it
     GenServer.call(__MODULE__, {:set_entities, new_state.entities})
   end
 
@@ -47,8 +46,10 @@ defmodule Doro.World.GameState do
     GenServer.call(__MODULE__, {:insert_entities, entities})
   end
 
-  def remove_entity(entity = %Entity{}) do
-    set(%{entities: get_entities(fn e -> e.id != entity.id end)})
+  def remove_entity(entity = %Entity{}), do: remove_entity(entity.id)
+
+  def remove_entity(entity_id) do
+    set(%{entities: get_entities(fn e -> e.id != entity_id end)})
   end
 
   defp all_entities do

--- a/lib/doro/world/world.ex
+++ b/lib/doro/world/world.ex
@@ -31,6 +31,8 @@ defmodule Doro.World do
     ])
   end
 
+  def remove_entity(entity_id), do: GameState.remove_entity(entity_id)
+
   def move_entity(entity, destination = %Entity{}), do: move_entity(entity, destination.id)
 
   def move_entity(entity, destination_id) when is_binary(destination_id) do

--- a/lib/doro_web/controllers/api/entities_controller.ex
+++ b/lib/doro_web/controllers/api/entities_controller.ex
@@ -46,6 +46,15 @@ defmodule DoroWeb.Api.EntitiesController do
     end
   end
 
+  @doc """
+  Destroy an entity (by id)
+  """
+  def destroy(conn, params = %{"id" => id}) do
+    Doro.World.remove_entity(id)
+    conn
+    |> json(%{message: "#{id} has been removed"})
+  end
+
   defp to_entity(params) do
     params
     |> atomize_keys

--- a/lib/doro_web/router.ex
+++ b/lib/doro_web/router.ex
@@ -24,7 +24,7 @@ defmodule DoroWeb.Router do
     pipe_through(:api)
     get("/entities", Api.EntitiesController, :index)
     put("/entities", Api.EntitiesController, :create)
-    post("/entities/:id", Api.EntitiesController, :update)
+    delete("/entities/:id", Api.EntitiesController, :destroy)
     get("/behaviors", Api.BehaviorsController, :index)
   end
 end

--- a/test/doro/world/game_state_test.exs
+++ b/test/doro/world/game_state_test.exs
@@ -32,6 +32,16 @@ defmodule Doro.World.GameStateTest do
     end
   end
 
+  describe "remove_entity/1" do
+    test "removes the entity by id" do
+      assert length(GameState.get_entities()) == 2
+      GameState.remove_entity(%Entity{id: "iceman"})
+      assert length(GameState.get_entities()) == 1
+      refute GameState.get_entity("iceman")
+      assert GameState.get_entity("maverick")
+    end
+  end
+
   describe "get_entity/1" do
     test "returns an entity with the given id, or nil" do
       assert %Entity{id: "iceman"} = GameState.get_entity("iceman")


### PR DESCRIPTION
Problem
--------
If we can add entities to the game, we should be able to delete them.  *But* if you allow deletion of anything,  you could get the main game state in real mess.  Imagine if you can delete `start` or the location you are in...

Solution
--------

Allow deletion of items that have been added via the editor only (not those from other sources).  This doesn't quite solve everything because if you decide to edit the location you're in, then you could delete it.  But at some point the editor needs to know that they could cause trouble.

Changes
---------
In GameStateEditor Entities Tab
* Add delete button for elements that have no src (have been edited in the game)
* Hook up delete button
* add backend support for deleting entities

* Hook up edit button for each element
* update TabSet so that it's run by redux props (instead of state)
* make sure everytime you edit, you show the "Editor" tab
* Add buttons for download all and download new and hook them up

In God behavior
* add ability to edit the location you're in as well as all the objects in that location.

Screencap
-----------
![doro-editing](https://user-images.githubusercontent.com/427380/45601156-4c02a780-b9bd-11e8-8677-cab74b589123.gif)
